### PR TITLE
fix: execute onClose listener independent of dialog fragment

### DIFF
--- a/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
@@ -222,19 +222,25 @@ class Ketch private constructor(
                 }
 
                 override fun onClose(status: HideExperienceStatus) {
+
+                    // Dismiss dialog fragment
                     findDialogFragment()?.let {
                         (it as? KetchDialogFragment)?.dismiss()
-                        this@Ketch.listener?.onDismiss(status)
                     }
+
+                    // Execute onDismiss event listener
+                    this@Ketch.listener?.onDismiss(status)
                 }
 
                 override fun onTapOutside() {
+
+                    // Dismiss dialog fragment
                     findDialogFragment()?.let {
-                        (it as? KetchDialogFragment)?.let {
-                            it.dismiss()
-                            this@Ketch.listener?.onDismiss(HideExperienceStatus.None)
-                        }
+                        (it as? KetchDialogFragment)?.dismiss()
                     }
+
+                    // Execute onDismiss event listener
+                    this@Ketch.listener?.onDismiss(HideExperienceStatus.None)
                 }
 
                 private fun showConsentPopup() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> Executes the onClose listener whether a dialog fragment is found or not. This is to handle the case where status = `willNotShow`, as the dialog fragment won't exist in this case. In general it doesn't make sense to depend on the dialog fragment for this listener, and this isn't obvious to the app developer

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Local with SDK sample app

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
<img width="1793" alt="image" src="https://github.com/ketch-com/ketch-android/assets/45305362/074850ef-c503-4066-bd1d-b52de5bc56a8">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
