### PR TITLE
fix: change to sync write method

### DIFF
--- a/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
@@ -129,8 +129,8 @@ class Ketch private constructor(
      * @param tabs: list of preferences tab
      * @param tab: the current tab
      */
-    fun showPreferencesTab(tabs: List<PreferencesTab>, tab: PreferencesTab, synchronousPreferences: Boolean = false) {
-        createWebView(false, synchronousPreferences)?.load(
+    fun showPreferencesTab(tabs: List<PreferencesTab>, tab: PreferencesTab, shouldRetry: Boolean = false, synchronousPreferences: Boolean = false) {
+        createWebView(shouldRetry, synchronousPreferences)?.load(
             orgCode,
             property,
             language,

--- a/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
@@ -66,8 +66,8 @@ class Ketch private constructor(
     /**
      * Loads a web page and shows a popup if necessary
      */
-    fun load(shouldRetry: Boolean = false) {
-        createWebView(shouldRetry)?.load(
+    fun load(shouldRetry: Boolean = false, synchronousPreferences: Boolean = false) {
+        createWebView(shouldRetry, synchronousPreferences)?.load(
             orgCode,
             property,
             language,
@@ -86,8 +86,8 @@ class Ketch private constructor(
     /**
      * Display the consent, adding the fragment dialog to the given FragmentManager.
      */
-    fun showConsent(shouldRetry: Boolean = false) {
-        createWebView(shouldRetry)?.load(
+    fun showConsent(shouldRetry: Boolean = false, synchronousPreferences: Boolean = false) {
+        createWebView(shouldRetry, synchronousPreferences)?.load(
             orgCode,
             property,
             language,
@@ -106,8 +106,8 @@ class Ketch private constructor(
     /**
      * Display the preferences, adding the fragment dialog to the given FragmentManager.
      */
-    fun showPreferences(shouldRetry: Boolean = false) {
-        createWebView(shouldRetry)?.load(
+    fun showPreferences(shouldRetry: Boolean = false, synchronousPreferences: Boolean = false) {
+        createWebView(shouldRetry, synchronousPreferences)?.load(
             orgCode,
             property,
             language,
@@ -129,8 +129,8 @@ class Ketch private constructor(
      * @param tabs: list of preferences tab
      * @param tab: the current tab
      */
-    fun showPreferencesTab(tabs: List<PreferencesTab>, tab: PreferencesTab, shouldRetry: Boolean = false) {
-        createWebView(shouldRetry)?.load(
+    fun showPreferencesTab(tabs: List<PreferencesTab>, tab: PreferencesTab, synchronousPreferences: Boolean = false) {
+        createWebView(false, synchronousPreferences)?.load(
             orgCode,
             property,
             language,
@@ -203,7 +203,7 @@ class Ketch private constructor(
         KetchSharedPreferences(it)
     }
 
-    private fun createWebView(shouldRetry: Boolean = false): KetchWebView? {
+    private fun createWebView(shouldRetry: Boolean = false, synchronousPreferences: Boolean = false): KetchWebView? {
 
         val webView = context.get()?.let { KetchWebView(it, shouldRetry) } ?: return null
 
@@ -245,17 +245,17 @@ class Ketch private constructor(
             }
 
             override fun onUSPrivacyUpdated(values: Map<String, Any?>) {
-                getPreferences()?.saveUSPrivacy(values)
+                getPreferences()?.saveUSPrivacy(values, synchronousPreferences)
                 this@Ketch.listener?.onUSPrivacyUpdated(values)
             }
 
             override fun onTCFUpdated(values: Map<String, Any?>) {
-                getPreferences()?.saveTCFTC(values)
+                getPreferences()?.saveTCFTC(values, synchronousPreferences)
                 this@Ketch.listener?.onTCFUpdated(values)
             }
 
             override fun onGPPUpdated(values: Map<String, Any?>) {
-                getPreferences()?.saveGPP(values)
+                getPreferences()?.saveGPP(values, synchronousPreferences)
                 this@Ketch.listener?.onGPPUpdated(values)
             }
 

--- a/ketchsdk/src/main/java/com/ketch/android/KetchSharedPreferences.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/KetchSharedPreferences.kt
@@ -28,7 +28,8 @@ internal class KetchSharedPreferences(context: Context) {
                     else -> putString(key, value.toString())
                 }
             }
-            apply()
+            // We used the synchronous write method so shared_preferences values are available to ad vendors asap
+            commit()
             Log.d(TAG, logMessage)
         }
     }

--- a/ketchsdk/src/main/java/com/ketch/android/KetchSharedPreferences.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/KetchSharedPreferences.kt
@@ -33,6 +33,7 @@ internal class KetchSharedPreferences(context: Context) {
                 Log.d(TAG, "$logMessage - $result")
             } else {
                 apply()
+                Log.d(TAG, logMessage)
             }
         }
     }

--- a/ketchsdk/src/main/java/com/ketch/android/KetchSharedPreferences.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/KetchSharedPreferences.kt
@@ -15,7 +15,7 @@ internal class KetchSharedPreferences(context: Context) {
 
     fun getSavedValue(key: String): String? = sharedPreferences.getString(key, null)
 
-    private fun saveValues(values: Map<String, Any?>, logMessage: String) {
+    private fun saveValues(values: Map<String, Any?>, logMessage: String, synchronousPreferences: Boolean = false) {
         sharedPreferences.edit {
             values.forEach { (key, value) ->
                 when (value) {
@@ -28,22 +28,25 @@ internal class KetchSharedPreferences(context: Context) {
                     else -> putString(key, value.toString())
                 }
             }
-            // We used the synchronous write method so shared_preferences values are available to ad vendors asap
-            commit()
-            Log.d(TAG, logMessage)
+            if (synchronousPreferences) {
+                val result = commit()
+                Log.d(TAG, "$logMessage - $result")
+            } else {
+                apply()
+            }
         }
     }
 
-    fun saveTCFTC(values: Map<String, Any?>) {
-        saveValues(values, "$IAB_TCF_TC_STRING is saved")
+    fun saveTCFTC(values: Map<String, Any?>, synchronousPreferences: Boolean = false) {
+        saveValues(values, "$IAB_TCF_TC_STRING is saved", synchronousPreferences)
     }
 
-    fun saveUSPrivacy(values: Map<String, Any?>) {
-        saveValues(values, "$IAB_US_PRIVACY_STRING is saved")
+    fun saveUSPrivacy(values: Map<String, Any?>, synchronousPreferences: Boolean = false) {
+        saveValues(values, "$IAB_US_PRIVACY_STRING is saved", synchronousPreferences)
     }
 
-    fun saveGPP(values: Map<String, Any?>) {
-        saveValues(values, "$IAB_GPP_HDR_GPP_STRING is saved")
+    fun saveGPP(values: Map<String, Any?>, synchronousPreferences: Boolean = false) {
+        saveValues(values, "$IAB_GPP_HDR_GPP_STRING is saved", synchronousPreferences)
     }
 
     companion object {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> Adds a param to control whether `apply` (async) or `commit` (sync) is used when writing to shared preferences. The synchronous option is desirable when values in shared preferences must be available as soon as possible, but this may cause other commits to be overitten.

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Local in sample app

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
