### PR TITLE
fix: store webViewClient ref as its own val

### DIFF
--- a/ketchsdk/src/main/java/com/ketch/android/ui/KetchWebView.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/ui/KetchWebView.kt
@@ -40,9 +40,10 @@ const val INITIAL_RELOAD_DELAY = 4000L
 class KetchWebView(context: Context, shouldRetry: Boolean = false) : WebView(context) {
 
     var listener: WebViewListener? = null
+    private val localContentWebViewClient = LocalContentWebViewClient(shouldRetry)
 
     init {
-        webViewClient = LocalContentWebViewClient(shouldRetry)
+        webViewClient = localContentWebViewClient
         settings.javaScriptEnabled = true
         setBackgroundColor(context.getColor(android.R.color.transparent))
 
@@ -74,7 +75,7 @@ class KetchWebView(context: Context, shouldRetry: Boolean = false) : WebView(con
 
     // Cancel any coroutines in KetchWebView and fully tear down webview to prevent memory leaks
     fun kill() {
-        (webViewClient as LocalContentWebViewClient).cancelCoroutines()
+        localContentWebViewClient.cancelCoroutines()
         stopLoading()
         clearHistory()
         clearCache(true)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> Avoids crash when instantiating webViewClient directly as a LocalContentWebViewClient object, instead create a separate val so we can guarantee it stays the same type

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Local with sample app

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://ketch-com.atlassian.net/browse/KD-14089

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
