### PR TITLE
fix: crash when dismissing

### DIFF
--- a/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
@@ -151,7 +151,7 @@ class Ketch private constructor(
      */
     fun dismissDialog() {
         findDialogFragment()?.let {
-            (it as? KetchDialogFragment)?.dismiss()
+            (it as? KetchDialogFragment)?.dismissAllowingStateLoss()
             this@Ketch.listener?.onDismiss(HideExperienceStatus.None)
         }
     }
@@ -194,7 +194,7 @@ class Ketch private constructor(
 
     init {
         findDialogFragment()?.let { dialog ->
-            (dialog as KetchDialogFragment).dismiss()
+            (dialog as KetchDialogFragment).dismissAllowingStateLoss()
             this@Ketch.listener?.onDismiss(HideExperienceStatus.None)
         }
     }
@@ -307,7 +307,7 @@ class Ketch private constructor(
             override fun onClose(status: HideExperienceStatus) {
                 // Dismiss dialog fragment
                 findDialogFragment()?.let {
-                    (it as? KetchDialogFragment)?.dismiss()
+                    (it as? KetchDialogFragment)?.dismissAllowingStateLoss()
                 }
 
                 // Execute onDismiss event listener
@@ -317,7 +317,7 @@ class Ketch private constructor(
             override fun onTapOutside() {
                 // Dismiss dialog fragment
                 findDialogFragment()?.let {
-                    (it as? KetchDialogFragment)?.dismiss()
+                    (it as? KetchDialogFragment)?.dismissAllowingStateLoss()
 
                     // Execute onDismiss event listener
                     this@Ketch.listener?.onDismiss(HideExperienceStatus.None)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> Fixes crash that occurs when dismissing the webview, it is safe to use `dismissAllowingStateLoss` as we don't need to preserve the state of a closed dialog fragment

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Local with sample app

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
