### PR TITLE
fix(shared-preferences): clear privacy protocol keys

### DIFF
--- a/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
@@ -38,14 +38,14 @@ class Ketch private constructor(
      *
      * @return Returns the preference value if it exists
      */
-    fun getSavedString(key: String) = getPreferences()?.getSavedValue(key)
+    fun getSavedString(key: String) = getPreferences().getSavedValue(key)
 
     /**
      * Retrieve IABTCF_TCString value from the preferences.
      *
      * @return Returns the preference value if it exists
      */
-    fun getTCFTCString() = getPreferences()?.getSavedValue(KetchSharedPreferences.IAB_TCF_TC_STRING)
+    fun getTCFTCString() = getPreferences().getSavedValue(KetchSharedPreferences.IAB_TCF_TC_STRING)
 
     /**
      * Retrieve IABUSPrivacy_String value from the preferences.
@@ -53,7 +53,7 @@ class Ketch private constructor(
      * @return Returns the preference value if it exists
      */
     fun getUSPrivacyString() =
-        getPreferences()?.getSavedValue(KetchSharedPreferences.IAB_US_PRIVACY_STRING)
+        getPreferences().getSavedValue(KetchSharedPreferences.IAB_US_PRIVACY_STRING)
 
     /**
      * Retrieve IABGPP_HDR_GppString value from the preferences.
@@ -61,7 +61,7 @@ class Ketch private constructor(
      * @return Returns the preference value if it exists
      */
     fun getGPPHDRGppString() =
-        getPreferences()?.getSavedValue(KetchSharedPreferences.IAB_GPP_HDR_GPP_STRING)
+        getPreferences().getSavedValue(KetchSharedPreferences.IAB_GPP_HDR_GPP_STRING)
 
     /**
      * Loads a web page and shows a popup if necessary
@@ -193,14 +193,22 @@ class Ketch private constructor(
     }
 
     init {
+
+        getPreferences()
+
         findDialogFragment()?.let { dialog ->
             (dialog as KetchDialogFragment).dismissAllowingStateLoss()
             this@Ketch.listener?.onDismiss(HideExperienceStatus.None)
         }
     }
 
-    private fun getPreferences(): KetchSharedPreferences? = context.get()?.let {
-        KetchSharedPreferences(it)
+    // Get the singleton KetchSharedPreferences object
+    private fun getPreferences(): KetchSharedPreferences {
+        context.get()?.let {
+            // Initialize will create KetchSharedPreferences if it doesn't already exist
+            KetchSharedPreferences.initialize(it)
+        }
+        return KetchSharedPreferences
     }
 
     private fun createWebView(shouldRetry: Boolean = false, synchronousPreferences: Boolean = false): KetchWebView? {
@@ -245,17 +253,17 @@ class Ketch private constructor(
             }
 
             override fun onUSPrivacyUpdated(values: Map<String, Any?>) {
-                getPreferences()?.saveUSPrivacy(values, synchronousPreferences)
+                getPreferences().saveValues(values, "USPrivacy", synchronousPreferences)
                 this@Ketch.listener?.onUSPrivacyUpdated(values)
             }
 
             override fun onTCFUpdated(values: Map<String, Any?>) {
-                getPreferences()?.saveTCFTC(values, synchronousPreferences)
+                getPreferences().saveValues(values, "TCF", synchronousPreferences)
                 this@Ketch.listener?.onTCFUpdated(values)
             }
 
             override fun onGPPUpdated(values: Map<String, Any?>) {
-                getPreferences()?.saveGPP(values, synchronousPreferences)
+                getPreferences().saveValues(values, "GPP", synchronousPreferences)
                 this@Ketch.listener?.onGPPUpdated(values)
             }
 

--- a/ketchsdk/src/main/java/com/ketch/android/KetchSharedPreferences.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/KetchSharedPreferences.kt
@@ -6,16 +6,65 @@ import androidx.preference.PreferenceManager
 import android.util.Log
 import androidx.core.content.edit
 
-internal class KetchSharedPreferences(context: Context) {
-    private val sharedPreferences: SharedPreferences
+/**
+ * KetchSharedPreferences is a singleton object which handles writing to Android SharedPreferences.
+ */
+object KetchSharedPreferences {
+    private lateinit var sharedPreferences: SharedPreferences
+    private var isInitialized = false
 
-    init {
-        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+    // Prefixes to remove during initialization
+    private val PREFIXES_TO_REMOVE = listOf("IABTCF", "IABGPP", "IABUS")
+
+    // Key names for retrieving each string
+    const val IAB_TCF_TC_STRING = "IABTCF_TCString"
+    const val IAB_US_PRIVACY_STRING = "IABUSPrivacy_String"
+    const val IAB_GPP_HDR_GPP_STRING = "IABGPP_HDR_GppString"
+
+    // Logging tag
+    private val TAG = KetchSharedPreferences::class.java.simpleName
+
+    /**
+     * Initialize SharedPreferences if it doesn't already exist
+     */
+    fun initialize(context: Context) {
+        if (!isInitialized) {
+            sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+            isInitialized = true
+
+            // Clear entries with specific prefixes
+            clearEntriesWithPrefixes()
+
+            Log.d(TAG, "Initialized KetchSharedPreferences")
+        }
     }
 
+    /**
+     * Clear all SharedPreferences keys with the prefixes in PREFIXES_TO_REMOVE
+     */
+    private fun clearEntriesWithPrefixes() {
+        val keysToRemove = sharedPreferences.all.keys.filter { key ->
+            PREFIXES_TO_REMOVE.any { key.startsWith(it) }
+        }
+
+        sharedPreferences.edit().apply {
+            keysToRemove.forEach { remove(it) }
+            apply()
+        }
+
+        // Log the result
+        Log.d(TAG, "Cleared ${keysToRemove.size} keys while initializing KetchSharedPreferences")
+    }
+
+    /**
+     * Retrieve some value from SharedPreferences
+     */
     fun getSavedValue(key: String): String? = sharedPreferences.getString(key, null)
 
-    private fun saveValues(values: Map<String, Any?>, logMessage: String, synchronousPreferences: Boolean = false) {
+    /**
+     * Save a map of values in SharedPreferences, using either apply (async) or commit (sync)
+     */
+    fun saveValues(values: Map<String, Any?>, logTag: String, synchronousPreferences: Boolean = false) {
         sharedPreferences.edit {
             values.forEach { (key, value) ->
                 when (value) {
@@ -30,30 +79,11 @@ internal class KetchSharedPreferences(context: Context) {
             }
             if (synchronousPreferences) {
                 val result = commit()
-                Log.d(TAG, "$logMessage - $result")
+                Log.d(TAG, "$logTag - Saved ${values.size} keys. Commit result: $result")
             } else {
                 apply()
-                Log.d(TAG, logMessage)
+                Log.d(TAG, "$logTag - Saved ${values.size} keys. Changes applied asynchronously.")
             }
         }
-    }
-
-    fun saveTCFTC(values: Map<String, Any?>, synchronousPreferences: Boolean = false) {
-        saveValues(values, "$IAB_TCF_TC_STRING is saved", synchronousPreferences)
-    }
-
-    fun saveUSPrivacy(values: Map<String, Any?>, synchronousPreferences: Boolean = false) {
-        saveValues(values, "$IAB_US_PRIVACY_STRING is saved", synchronousPreferences)
-    }
-
-    fun saveGPP(values: Map<String, Any?>, synchronousPreferences: Boolean = false) {
-        saveValues(values, "$IAB_GPP_HDR_GPP_STRING is saved", synchronousPreferences)
-    }
-
-    companion object {
-        private val TAG = KetchSharedPreferences::class.java.simpleName
-        internal const val IAB_TCF_TC_STRING = "IABTCF_TCString"
-        internal const val IAB_US_PRIVACY_STRING = "IABUSPrivacy_String"
-        internal const val IAB_GPP_HDR_GPP_STRING = "IABGPP_HDR_GppString"
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

- When the SDK is initialized, clear all privacy protocol keys in shared preferences. This assures only the correct keys are written based on the current jurisdiction
    - This is done by converting the `KetchSharedPreferences` object to a singleton, and doing the deletion of old keys when the singleton is first created, which happens when KetchSDK.create() is called.

Columbia (usprivacy):
<img width="633" alt="Screenshot 2025-01-09 at 4 48 02 PM" src="https://github.com/user-attachments/assets/45f71093-d245-4448-a5ce-4f2a84ff4e4d" />

France (usprivacy + gpp + tcf):
<img width="1185" alt="Screenshot 2025-01-09 at 4 48 26 PM" src="https://github.com/user-attachments/assets/fd819664-65c6-4d40-9462-9d06baa4f337" />

California (usprivacy + gpp):
<img width="884" alt="Screenshot 2025-01-09 at 4 48 39 PM" src="https://github.com/user-attachments/assets/2ebbb3a9-86d3-4505-ab44-0ca74bafdefc" />

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Locally, with different juridictions each having different privacy protocol configurations

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
