### PR TITLE
KD-15605: destroy webView asynchronously to prevent ANR, KetchDialogFragment optimisation

### DIFF
--- a/ketchsdk/src/main/java/com/ketch/android/ui/KetchDialogFragment.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/ui/KetchDialogFragment.kt
@@ -72,32 +72,18 @@ internal class KetchDialogFragment : DialogFragment() {
     }
 
     fun show(manager: FragmentManager) {
-        try {
-            // Check for any existing fragment with the same tag and remove it
-            val existingFragment = manager.findFragmentByTag(TAG)
-            if (existingFragment != null) {
-                try {
-                    Log.d(TAG, "Found existing fragment, removing it first")
-                    val transaction = manager.beginTransaction()
-                    transaction.remove(existingFragment)
-                    transaction.commitAllowingStateLoss()
-                    manager.executePendingTransactions()
-                } catch (e: Exception) {
-                    Log.e(TAG, "Error removing existing fragment: ${e.message}")
-                }
-            }
-
-            val transaction = manager.beginTransaction()
-            transaction.add(this, TAG)
-            transaction.commitAllowingStateLoss()
-
-            // Execute transaction immediately
+        // Check for any existing fragment with the same tag and remove it
+        (manager.findFragmentByTag(TAG) as? KetchDialogFragment)?.let { existingFragment ->
             try {
-                manager.executePendingTransactions()
+                Log.d(TAG, "Found existing fragment, dismissing it first")
+                existingFragment.dismiss()
             } catch (e: Exception) {
-                Log.e(TAG, "Error executing pending transactions: ${e.message}")
+                Log.e(TAG, "Error dismissing existing fragment: ${e.message}")
             }
+        }
 
+        try {
+            this.show(manager, TAG)
         } catch (e: Exception) {
             Log.e(TAG, "Error showing dialog: ${e.message}")
             onDismissCallback?.invoke()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> Description here

## Why is this change being made?

- [x] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.
