### PR TITLE
Add AGENTS.md for Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is the **Ketch Android SDK** — a Gradle multi-module Android library project (not a monorepo).
+
+### Modules
+
+| Module | Type | Purpose |
+|---|---|---|
+| `ketchsdk` | Android Library | Core SDK (the publishable artifact) |
+| `integration-tests` | Android App | Instrumented tests (require emulator/device) |
+| `sample-app-standard` | Android App | Demo using Android Views + ViewBinding |
+| `sample-app-compose` | Android App | Demo using Jetpack Compose + Material 3 |
+
+### Prerequisites
+
+- **JDK 17** (`openjdk-17-jdk-headless`) — required by Gradle and AGP 9.x
+- **Android SDK** with platform `android-36`, `build-tools;36.0.0`, and `platform-tools`
+- Environment variables: `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64`, `ANDROID_HOME=/opt/android-sdk`
+
+### Key commands
+
+See `build.gradle` and per-module `build.gradle` files for full configuration. Quick reference:
+
+| Task | Command |
+|---|---|
+| Build all modules (debug) | `./gradlew assembleDebug` |
+| Build SDK only | `./gradlew :ketchsdk:assembleDebug` |
+| Unit tests | `./gradlew :ketchsdk:test` |
+| Ktlint | `./gradlew ktlintCheck` |
+| Android Lint | `./gradlew :ketchsdk:lintDebug` |
+| Instrumented tests | `./gradlew :integration-tests:connectedAndroidTest` (requires emulator) |
+| Clean | `./gradlew clean` |
+
+### Gotchas
+
+- The default JDK on the VM is JDK 21. You **must** set `JAVA_HOME` to the JDK 17 path, otherwise Gradle will fail with compatibility errors (AGP 9.0.0 + Kotlin 2.1.20 target JDK 17).
+- Instrumented/integration tests (`connectedAndroidTest`) require a running Android emulator or physical device. These cannot run headlessly in this Cloud VM environment.
+- The `GITHUB_RUN_NUMBER` env var is referenced in `build.gradle` for versioning; it defaults to `null` in local builds which is fine.
+- Gradle deprecation warnings about `android.*` properties are expected and non-blocking; they warn about defaults changing in AGP 10.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description of this change

Adds `AGENTS.md` with Cursor Cloud specific development environment instructions for the Ketch Android SDK. This file provides future cloud agents with the necessary context to build, test, and lint the project without trial and error.

## Why is this change being made?

- [x] Chore (non-functional changes)

This is a non-functional addition of developer documentation for automated cloud agent environments.

## How was this tested? How can the reviewer verify your testing?

The full development environment was set up and verified:

- **JDK 17** installed and configured
- **Android SDK** (platform 36, build-tools 36.0.0) installed
- All 4 modules built successfully (`./gradlew assembleDebug`)
- Unit tests pass (`./gradlew :ketchsdk:test`)
- Ktlint passes (`./gradlew ktlintCheck`)
- Android Lint passes (`./gradlew :ketchsdk:lintDebug`)

Build verification log:
[build_verification.log](https://cursor.com/agents/bc-eb96f6f0-bf6c-4bc9-9f68-dcd9d1c3fab4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild_verification.log)

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb96f6f0-bf6c-4bc9-9f68-dcd9d1c3fab4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb96f6f0-bf6c-4bc9-9f68-dcd9d1c3fab4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

