### PR TITLE
feat: add age band query params to Android SDK

### DIFF
--- a/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
@@ -40,6 +40,9 @@ class Ketch private constructor(
     private var jurisdiction: String? = null
     private var region: String? = null
     private var cssStyle: String? = null
+    private var age: Int? = null
+    private var ageLower: Int? = null
+    private var ageUpper: Int? = null
 
     // Flag to prevent multiple overlapping experiences
     @Volatile
@@ -117,6 +120,9 @@ class Ketch private constructor(
                 null,
                 ketchUrl,
                 logLevel,
+                age,
+                ageLower,
+                ageUpper,
                 bottomPadding,
                 topPadding,
                 cssStyle
@@ -158,6 +164,9 @@ class Ketch private constructor(
                 null,
                 ketchUrl,
                 logLevel,
+                age,
+                ageLower,
+                ageUpper,
                 bottomPadding,
                 topPadding,
                 cssStyle
@@ -199,6 +208,9 @@ class Ketch private constructor(
                 null,
                 ketchUrl,
                 logLevel,
+                age,
+                ageLower,
+                ageUpper,
                 bottomPadding,
                 topPadding,
                 cssStyle
@@ -244,6 +256,9 @@ class Ketch private constructor(
                 tab,
                 ketchUrl,
                 logLevel,
+                age,
+                ageLower,
+                ageUpper,
                 bottomPadding,
                 topPadding,
                 cssStyle
@@ -318,6 +333,36 @@ class Ketch private constructor(
      */
     fun setCssStyle(cssStyle: String?) {
         this.cssStyle = validateCssStyle(cssStyle)
+    }
+
+    /**
+     * Set the exact age of the user.
+     * Used for age band resolution to determine the appropriate legal basis for each purpose.
+     *
+     * @param age: the user's exact age
+     */
+    fun setAge(age: Int?) {
+        this.age = age
+    }
+
+    /**
+     * Set the lower bound of the user's age range.
+     * Used for age band resolution when an exact age is not known.
+     *
+     * @param ageLower: the lower bound of the user's age range
+     */
+    fun setAgeLower(ageLower: Int?) {
+        this.ageLower = ageLower
+    }
+
+    /**
+     * Set the upper bound of the user's age range.
+     * Used for age band resolution when an exact age is not known.
+     *
+     * @param ageUpper: the upper bound of the user's age range
+     */
+    fun setAgeUpper(ageUpper: Int?) {
+        this.ageUpper = ageUpper
     }
 
     private fun validateCssStyle(cssStyle: String?): String? {

--- a/ketchsdk/src/main/java/com/ketch/android/data/Index.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/data/Index.kt
@@ -18,6 +18,9 @@ fun getIndexHtml(
     forceShow: String? = null,
     preferencesTabs: String? = null,
     preferencesTab: String? = null,
+    age: Int? = null,
+    ageLower: Int? = null,
+    ageUpper: Int? = null,
     bottomPadding: String = "0px",
     topPadding: String = "0px",
     cssStyleOverride: String? = null
@@ -199,6 +202,21 @@ fun getIndexHtml(
             } +
             if (environment?.isNotBlank() == true) {
                 "ketch_env: \"${environment}\","
+            } else {
+                ""
+            } +
+            if (age != null && age >= 0) {
+                "ketch_age: \"${age}\","
+            } else {
+                ""
+            } +
+            if (ageLower != null && ageLower >= 0) {
+                "ketch_age_lower: \"${ageLower}\","
+            } else {
+                ""
+            } +
+            if (ageUpper != null && ageUpper >= 0) {
+                "ketch_age_upper: \"${ageUpper}\","
             } else {
                 ""
             } +

--- a/ketchsdk/src/main/java/com/ketch/android/ui/KetchWebView.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/ui/KetchWebView.kt
@@ -214,6 +214,9 @@ class KetchWebView(context: Context, shouldRetry: Boolean = false) : WebView(con
         preferencesTab: Ketch.PreferencesTab?,
         ketchUrl: String?,
         logLevel: Ketch.LogLevel,
+        age: Int?,
+        ageLower: Int?,
+        ageUpper: Int?,
         bottomPadding: Int?,
         topPadding: Int?,
         cssStyle: String?
@@ -245,6 +248,9 @@ class KetchWebView(context: Context, shouldRetry: Boolean = false) : WebView(con
             forceShow = forceShow?.getUrlParameter(),
             preferencesTabs = preferencesTabs.takeIf { it.isNotEmpty() }?.joinToString(",") { it.getUrlParameter() },
             preferencesTab = preferencesTab?.getUrlParameter(),
+            age = age,
+            ageLower = ageLower,
+            ageUpper = ageUpper,
             bottomPadding = bottomPaddingPx,
             topPadding = topPaddingPx,
             cssStyleOverride = cssStyle


### PR DESCRIPTION
## Description of this change

> Adds support for age band query params (`ketch_age`, `ketch_age_lower`, `ketch_age_upper`) to the Android SDK so ketch-tag can apply age-based legal basis overrides per purpose.
>
> - Added `age`, `ageLower`, and `ageUpper` private fields to `Ketch.kt` with `setAge()`, `setAgeLower()`, and `setAgeUpper()` setter methods
> - Threaded age params through `KetchWebView.load()` to `getIndexHtml()`
> - Added conditional age param injection in `Index.kt` with `>= 0` validation to guard against negative values

<img width="2038" height="1004" alt="Screenshot 2026-04-15 at 5 28 17 PM" src="https://github.com/user-attachments/assets/b74f70e6-1366-4548-bb30-33c8a28e2b1f" />

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

> Tested Locally:
>
> - Ran `sample-app-standard` on Android emulator (Pixel 8, API 37) with `setAge(15)` — confirmed `ketch_age:"15"` appears in Logcat via `Ketch Parameters BEFORE` log
> - Ran with `setAgeLower(13)` and `setAgeUpper(17)` — confirmed `ketch_age_lower:"13"` and `ketch_age_upper:"17"` appear and `ketch_age` is absent

## Related issues

[KD-17064](https://ketch-com.atlassian.net/browse/KD-17064)

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.

[KD-17064]: https://ketch-com.atlassian.net/browse/KD-17064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change that only affects how optional parameters are passed into the WebView; main risk is unintended behavior if callers pass conflicting/invalid age values.
> 
> **Overview**
> Adds optional age inputs to the Android SDK and forwards them into the embedded Ketch Tag initialization.
> 
> `Ketch` now stores `age`, `ageLower`, and `ageUpper` via new setters, threads these through all experience entrypoints into `KetchWebView.load()`, and `getIndexHtml()` conditionally injects `ketch_age`, `ketch_age_lower`, and `ketch_age_upper` (only when non-null and `>= 0`) into the generated query parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d507d50f36c76229e8aad03717e2f8c65c844278. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->