### PR TITLE
fix(android): release WebView on dialog onDestroyView

### DIFF
--- a/ketchsdk/src/main/java/com/ketch/android/ui/KetchDialogFragment.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/ui/KetchDialogFragment.kt
@@ -32,12 +32,21 @@ internal class KetchDialogFragment : DialogFragment() {
             requestWindowFeature(Window.FEATURE_NO_TITLE)
         }
 
+    override fun onDestroyView() {
+        if (activity?.isChangingConfigurations != true) {
+            releaseWebViewReferences()
+        }
+        super.onDestroyView()
+    }
+
     override fun onDetach() {
         super.onDetach()
+        releaseWebViewReferences()
+    }
 
+    private fun releaseWebViewReferences() {
         onDismissCallback?.invoke()
         onDismissCallback = null
-
         webView = null
     }
 
@@ -50,7 +59,7 @@ internal class KetchDialogFragment : DialogFragment() {
                 dismissAllowingStateLoss()
             } catch (e2: Exception) {
                 Log.e(TAG, "Error during fallback dismissAllowingStateLoss: ${e2.message}")
-                onDismissCallback?.invoke()
+                releaseWebViewReferences()
             }
         }
     }
@@ -86,7 +95,7 @@ internal class KetchDialogFragment : DialogFragment() {
             this.show(manager, TAG)
         } catch (e: Exception) {
             Log.e(TAG, "Error showing dialog: ${e.message}")
-            onDismissCallback?.invoke()
+            releaseWebViewReferences()
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> Release `Ketch.activeWebView` when the dialog view is destroyed so LeakCanary no longer reports a detached `KetchWebView` retained after `onDestroyView`.
>
> - `ketchsdk/src/main/java/com/ketch/android/ui/KetchDialogFragment.kt`: add `releaseWebViewReferences()`, call from `onDestroyView` (skip when `isChangingConfigurations`), idempotent `onDetach`.

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- `./gradlew :ketchsdk:compileDebugKotlin --no-daemon` — pass
- `./gradlew :integration-tests:connectedAndroidTest --no-daemon` on Pixel_9a emulator — 12/12 pass

## Related issues

N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
