### PR TITLE
feat: add headless consent API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ build/
 /captures
 .externalNativeBuild
 .cxx
-.cursor/

--- a/README.md
+++ b/README.md
@@ -182,6 +182,68 @@ Feel free to skip the listeners you don't really need.
     }
 ```
 
+## Headless API (web/v3, pre-WebView)
+
+Use native HTTP for cold-start flows **before** loading the WebView—location, config, and consent with `protocols` from the CDN. Contract: [mobile-headless-api.md](https://github.com/ketch-com/ketch-tag/blob/main/docs/design/mobile-headless-api.md).
+
+Testing: [mobile-headless-api-testing.md](https://github.com/ketch-com/ketch-tag/blob/main/docs/design/mobile-headless-api-testing.md). (App Tracking Transparency is iOS-only — not applicable on Android.)
+
+Pass `dataCenter` when creating the SDK (`KetchDataCenter.US`, `EU`, or `UAT`). Instance methods use the SDK's data center; static `KetchSdk` methods accept an optional `dataCenter` parameter.
+
+```kotlin
+val ketch = KetchSdk.create(
+    activity = this,
+    fragmentManager = supportFragmentManager,
+    organization = ORG_CODE,
+    property = PROPERTY,
+    environment = ENVIRONMENT,
+    listener = listener,
+    dataCenter = KetchDataCenter.US,
+)
+
+// Recommended cold-start order
+ketch.fetchLocation { result -> /* jurisdiction hint */ }
+ketch.fetchBootstrapConfiguration { result -> /* boot.json */ }
+ketch.fetchFullConfiguration(
+    FullConfigurationRequest(
+        organizationCode = ORG_CODE,
+        propertyCode = PROPERTY,
+        environmentCode = ENVIRONMENT,
+        jurisdictionCode = "us-ca",
+        languageCode = "en-US",
+        hash = hashFromBootstrap,
+    )
+) { result -> /* full config */ }
+
+ketch.fetchConsent(consentConfig) { result ->
+    // Consent includes purposes and protocols (GPP, TCF, US Privacy, …)
+}
+ketch.setConsent(consentUpdate) { result ->
+    // Server-computed protocols in response; request omits protocols
+}
+
+// Rights, profile, subscriptions
+ketch.invokeRight(invokeRightRequest) { }
+ketch.getProfile(profileRequest) { }
+ketch.putProfile(putProfileRequest) { }
+ketch.getSubscriptions(subscriptionsRequest) { }
+ketch.setSubscriptions(subscriptionsRequest) { }
+
+// Subscriptions config, QR URL, telemetry
+ketch.fetchSubscriptionsConfiguration(subConfigRequest) { }
+val qrUrl = ketch.preferenceQRUrl(
+    PreferenceQRRequest(
+        organizationCode = ORG_CODE,
+        propertyCode = PROPERTY,
+        environmentCode = ENVIRONMENT,
+        imageSize = 1024,
+    )
+)
+ketch.webReport("mychannel", reportRequest) { }
+```
+
+`getConsent()` on the WebView listener path is unchanged. Headless calls do not require `load()`.
+
 ## Local Development Setup
 
 If you're developing or modifying the SDK and want to test your changes with the sample app, you can use Gradle's composite builds feature to link them together.

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ buildscript {
             'dokka'       : '1.9.20',
             'junit'       : '4.13.2',
             'gson'        : '2.13.2',
+            'okhttp'      : '4.12.0',
+            'coroutines'  : '1.10.2',
             'webkit'      : '1.15.0'
     ]
     repositories {

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,6 +1,8 @@
 # Ketch SDK Integration Tests
 
-This module contains integration tests for the Ketch Android SDK. The tests are designed to validate the SDK's functionality in a real Android environment.
+This module contains integration tests for the Ketch Android SDK. The tests validate SDK functionality in a real Android environment.
+
+**ATT is N/A on Android** — App Tracking Transparency is iOS-only. For ATT testing see [mobile-att-testing.md](../../ketch-tag/docs/design/mobile-att-testing.md#ketch-android). For headless CDN tests see [mobile-headless-api-testing.md](../../ketch-tag/docs/design/mobile-headless-api-testing.md#ketch-android).
 
 ## Overview
 
@@ -32,25 +34,40 @@ integration-tests/
 - An Android device or emulator running API 28 or higher
 - The Ketch SDK module (`ketchsdk`) must be built successfully
 
-### Running Tests Locally
+### Headless integration tests
+
+Live CDN round-trip (no WebView): `KetchHeadlessIntegrationTest` uses org `ketch_samples` / property `android`.
+
+```bash
+./gradlew :integration-tests:connectedAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=com.ketch.android.integration.tests.KetchHeadlessIntegrationTest
+```
+
+### WebView integration tests
+
+```bash
+# From the ketch-android directory
+./gradlew :integration-tests:connectedAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=com.ketch.android.integration.tests.KetchSdkIntegrationTest
+```
+
+## Running Tests Locally
 
 #### From Android Studio
 
 1. Open the `ketch-android` project in Android Studio
 2. Connect an Android device or start an emulator
 3. Navigate to `integration-tests/src/androidTest/java/com/ketch/android/integration/tests/`
-4. Right-click on `KetchSdkIntegrationTest` and select "Run 'KetchSdkIntegrationTest'"
+4. Right-click on the desired test class and select Run
 
 #### From Command Line
 
 ```bash
-# From the ketch-android directory
+# All integration tests
 ./gradlew :integration-tests:connectedAndroidTest
 ```
 
 ### Running the Sample App
-
-You can also run the sample app directly to manually test the SDK:
 
 ```bash
 ./gradlew :integration-tests:installDebug
@@ -58,21 +75,18 @@ You can also run the sample app directly to manually test the SDK:
 
 ## Test Coverage
 
-The current test suite covers:
-
-- **SDK Initialization**: Verifies the SDK initializes correctly
-- **UI Interactions**: Tests all buttons and their status updates
-- **Method Calls**: Validates that SDK methods are called without errors
-- **State Management**: Checks that the app displays initial state correctly
+| Suite | Class | What it validates |
+| ----- | ----- | ----------------- |
+| **Headless CDN** | `KetchHeadlessIntegrationTest` | `fetchLocation`, bootstrap, full config, consent get/set |
+| **WebView** | `KetchSdkIntegrationTest` | SDK init, UI buttons, WebView experience load |
 
 ## Sample App Features
 
 The sample app includes:
 
-- Buttons to trigger all major SDK methods (`load`, `showConsent`, `showPreferences`, etc.)
-- Status display to show current SDK state
+- Buttons to trigger SDK methods (`load`, `showConsent`, `showPreferences`, etc.)
+- Status display for SDK state and privacy framework values (TCF, US Privacy, GPP)
 - Real-time updates from SDK callbacks
-- Display of privacy framework values (TCF, US Privacy, GPP)
 
 ## Configuration
 
@@ -82,76 +96,27 @@ The sample app uses test configuration values:
 - **Property**: `test_property`
 - **Environment**: `test`
 
-To test with real values, update the constants in `MainActivity.kt`:
-
-```kotlin
-private const val ORG_CODE = "your_real_org_code"
-private const val PROPERTY = "your_real_property"
-private const val ENVIRONMENT = "production"
-```
+To test with real values, update the constants in `MainActivity.kt`.
 
 ## Adding New Tests
 
-To add new integration tests:
-
-1. Create test methods in `KetchSdkIntegrationTest.kt`
+1. Create test methods in the appropriate `*IntegrationTest.kt` class
 2. Use Espresso matchers and assertions
-3. Follow the existing test patterns
-4. Add any necessary helper methods
-
-Example test structure:
-
-```kotlin
-@Test
-fun testNewFeature() {
-    // Arrange
-    // Set up test conditions
-
-    // Act
-    // Perform actions (button clicks, etc.)
-
-    // Assert
-    // Verify expected outcomes
-}
-```
-
-## Future Enhancements
-
-Planned improvements:
-
-- [ ] Tests for dialog display and interaction
-- [ ] Network request mocking for controlled testing
-- [ ] Performance testing
-- [ ] Accessibility testing
-- [ ] Tests for different Android versions and devices
-- [ ] Integration with CI/CD pipelines
+3. Follow existing test patterns
+4. Keep headless tests in `KetchHeadlessIntegrationTest`; WebView tests in `KetchSdkIntegrationTest`
 
 ## Troubleshooting
 
-Common issues and solutions:
-
-**Tests fail with "No activities found"**
-
-- Ensure the sample app builds successfully
-- Check that the device/emulator is running
-
-**SDK initialization errors**
-
-- Verify the SDK module is included in dependencies
-- Check that test configuration values are valid
-
-**UI tests fail intermittently**
-
-- Add appropriate wait conditions for async operations
-- Ensure tests are running on a clean app state
+| Symptom | Likely cause |
+| ------- | ------------ |
+| Tests fail with "No activities found" | Sample app did not build; emulator not running |
+| SDK initialization errors | Invalid test configuration; missing SDK dependency |
+| UI tests fail intermittently | Missing wait for async WebView load |
 
 ## Dependencies
 
-The integration tests use:
+- **Espresso** — UI testing
+- **AndroidX Test** — test infrastructure
+- **JUnit 4** — test framework
 
-- **Espresso**: For UI testing
-- **AndroidX Test**: For test infrastructure
-- **JUnit 4**: For test framework
-- **Awaitility**: For async test conditions (if needed)
-
-All dependencies are automatically managed through the `build.gradle` file.
+All dependencies are managed through `build.gradle`.

--- a/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/HeadlessIntegrationSupport.kt
+++ b/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/HeadlessIntegrationSupport.kt
@@ -1,0 +1,68 @@
+package com.ketch.android.integration.tests
+
+import com.ketch.android.api.KetchDataCenter
+import com.ketch.android.data.ConsentConfig
+import com.ketch.android.data.HeadlessConfiguration
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertTrue
+
+object HeadlessIntegrationSupport {
+    const val ORG_CODE = "ketch_samples"
+    const val PROPERTY = "android"
+    const val ENVIRONMENT = "production"
+    const val TIMEOUT_SECONDS = 45L
+
+    fun uniqueEmailIdentity(): Map<String, String> =
+        mapOf("email" to "headless-${UUID.randomUUID()}@integration.ketch.test")
+
+    fun <T> awaitHeadless(block: (callback: (Result<T>) -> Unit) -> Unit): T {
+        val latch = CountDownLatch(1)
+        var result: Result<T>? = null
+        block { value ->
+            result = value
+            latch.countDown()
+        }
+        assertTrue(
+            "Headless call timed out after ${TIMEOUT_SECONDS}s",
+            latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+        )
+        return result!!.getOrElse { throw AssertionError("Headless call failed: ${it.message}", it) }
+    }
+
+    fun consentConfigFrom(
+        config: HeadlessConfiguration,
+        identities: Map<String, String>,
+        organizationCode: String = ORG_CODE,
+        propertyCode: String = PROPERTY,
+        environmentCode: String = ENVIRONMENT,
+    ): ConsentConfig {
+        val jurisdiction = config.jurisdiction?.code
+            ?: config.jurisdiction?.defaultJurisdictionCode
+            ?: "us"
+        val purposes = config.purposes
+            ?.mapNotNull { purpose ->
+                val code = purpose.code
+                val legalBasis = purpose.legalBasisCode
+                if (code != null && legalBasis != null) {
+                    code to ConsentConfig.PurposeLegalBasis(legalBasis)
+                } else {
+                    null
+                }
+            }
+            ?.toMap()
+            ?: emptyMap()
+        require(purposes.isNotEmpty()) { "Configuration returned no purposes" }
+        return ConsentConfig(
+            organizationCode = organizationCode,
+            propertyCode = propertyCode,
+            environmentCode = environmentCode,
+            jurisdictionCode = jurisdiction,
+            identities = identities,
+            purposes = purposes,
+        )
+    }
+
+    val dataCenter: KetchDataCenter = KetchDataCenter.UAT
+}

--- a/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/KetchHeadlessIntegrationTest.kt
+++ b/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/KetchHeadlessIntegrationTest.kt
@@ -1,0 +1,110 @@
+package com.ketch.android.integration.tests
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ketch.android.KetchSdk
+import com.ketch.android.data.ConsentUpdate
+import com.ketch.android.data.FullConfigurationRequest
+import com.ketch.android.integration.tests.HeadlessIntegrationSupport.ORG_CODE
+import com.ketch.android.integration.tests.HeadlessIntegrationSupport.PROPERTY
+import com.ketch.android.integration.tests.HeadlessIntegrationSupport.ENVIRONMENT
+import com.ketch.android.integration.tests.HeadlessIntegrationSupport.awaitHeadless
+import com.ketch.android.integration.tests.HeadlessIntegrationSupport.consentConfigFrom
+import com.ketch.android.integration.tests.HeadlessIntegrationSupport.dataCenter
+import com.ketch.android.integration.tests.HeadlessIntegrationSupport.uniqueEmailIdentity
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Live CDN headless round-trip tests (web/v3, sandbox org).
+ * Requires network on emulator/device. Does not use WebView.
+ */
+@RunWith(AndroidJUnit4::class)
+class KetchHeadlessIntegrationTest {
+
+    @Test
+    fun testFetchLocationReturnsGeoIP() {
+        val location = awaitHeadless { callback ->
+            KetchSdk.fetchLocation(dataCenter, callback)
+        }
+        assertNotNull("Expected location payload", location.location)
+        assertFalse(
+            "Expected countryCode from CDN",
+            location.location?.countryCode.isNullOrBlank(),
+        )
+    }
+
+    @Test
+    fun testFetchBootstrapConfiguration() {
+        val boot = awaitHeadless { callback ->
+            KetchSdk.fetchBootstrapConfiguration(ORG_CODE, PROPERTY, dataCenter, callback)
+        }
+        assertTrue(
+            "Bootstrap should include experiences metadata",
+            boot.experiences != null || boot.jurisdiction != null || !boot.purposes.isNullOrEmpty(),
+        )
+    }
+
+    @Test
+    fun testHeadlessColdStartConsentRoundTrip() {
+        val identities = uniqueEmailIdentity()
+
+        awaitHeadless { callback ->
+            KetchSdk.fetchLocation(dataCenter, callback)
+        }
+
+        val boot = awaitHeadless { callback ->
+            KetchSdk.fetchBootstrapConfiguration(ORG_CODE, PROPERTY, dataCenter, callback)
+        }
+
+        val fullConfig = awaitHeadless { callback ->
+            KetchSdk.fetchFullConfiguration(
+                FullConfigurationRequest(
+                    organizationCode = ORG_CODE,
+                    propertyCode = PROPERTY,
+                ),
+                dataCenter,
+                callback,
+            )
+        }
+
+        val consentConfig = consentConfigFrom(fullConfig, identities)
+
+        val consent = awaitHeadless { callback ->
+            KetchSdk.fetchConsent(consentConfig, dataCenter, callback)
+        }
+        assertTrue(
+            "CDN consent get should return protocols and/or purposes",
+            !consent.protocols.isNullOrEmpty() || !consent.purposes.isNullOrEmpty(),
+        )
+
+        val purposeCode = consentConfig.purposes.keys.first()
+        val legalBasis = consentConfig.purposes[purposeCode]!!
+
+        val update = ConsentUpdate(
+            organizationCode = ORG_CODE,
+            propertyCode = PROPERTY,
+            environmentCode = ENVIRONMENT,
+            identities = identities,
+            jurisdictionCode = consentConfig.jurisdictionCode,
+            migrationOption = ConsentUpdate.MigrationOption.MIGRATE_DEFAULT,
+            purposes = mapOf(
+                purposeCode to ConsentUpdate.PurposeAllowedLegalBasis(
+                    allowed = true,
+                    legalBasisCode = legalBasis.legalBasisCode,
+                ),
+            ),
+        )
+
+        val updated = awaitHeadless { callback ->
+            KetchSdk.setConsent(update, dataCenter, callback)
+        }
+        assertNotNull("setConsent should return purposes", updated.purposes)
+        assertTrue(
+            "setConsent should include updated purpose",
+            updated.purposes!!.containsKey(purposeCode),
+        )
+    }
+}

--- a/ketchsdk/build.gradle
+++ b/ketchsdk/build.gradle
@@ -65,10 +65,13 @@ dependencies {
     implementation "androidx.appcompat:appcompat:${versions.appcompat}"
     implementation "org.jetbrains.kotlin:kotlin-parcelize-runtime:${versions.kotlin}"
     implementation "com.google.code.gson:gson:${versions.gson}"
+    implementation "com.squareup.okhttp3:okhttp:${versions.okhttp}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutines}"
     implementation "androidx.webkit:webkit:${versions.webkit}"
     implementation "androidx.preference:preference:1.2.1"
 
     testImplementation "junit:junit:${versions.junit}"
+    testImplementation "com.squareup.okhttp3:mockwebserver:${versions.okhttp}"
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }

--- a/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
@@ -1,13 +1,32 @@
 package com.ketch.android
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
+import com.ketch.android.api.HeadlessApiClient
+import com.ketch.android.api.KetchDataCenter
 import com.ketch.android.data.Consent
+import com.ketch.android.data.ConsentConfig
+import com.ketch.android.data.ConsentUpdate
 import com.ketch.android.data.ContentDisplay
+import com.ketch.android.data.FullConfigurationRequest
+import com.ketch.android.data.GetProfileRequest
+import com.ketch.android.data.GetProfileResponse
+import com.ketch.android.data.HeadlessConfiguration
+import com.ketch.android.data.InvokeRightRequest
+import com.ketch.android.data.PreferenceQRRequest
+import com.ketch.android.data.PutProfileRequest
+import com.ketch.android.data.SubscriptionConfiguration
+import com.ketch.android.data.SubscriptionConfigurationRequest
+import com.ketch.android.data.SubscriptionsRequest
+import com.ketch.android.data.SubscriptionsResponse
+import com.ketch.android.data.WebReportRequest
 import com.ketch.android.data.HideExperienceStatus
 import com.ketch.android.data.KetchConfig
+import com.ketch.android.data.LocationResponse
 import com.ketch.android.data.WillShowExperienceType
 import com.ketch.android.ui.KetchDialogFragment
 import com.ketch.android.ui.KetchWebView
@@ -25,8 +44,12 @@ class Ketch private constructor(
     private val environment: String?,
     private val listener: Listener?,
     private val ketchUrl: String?,
-    private val logLevel: LogLevel
+    private val dataCenter: KetchDataCenter,
+    private val logLevel: LogLevel,
+    private val headlessApiClient: HeadlessApiClient,
+    private var webResourceUrlOverrides: Map<String, String> = emptyMap(),
 ) {
+    private val effectiveKetchUrl: String = ketchUrl ?: dataCenter.baseUrl
     // Weak reference to the original (Activity) context for WebView creation.
     // WebView requires an Activity context for native UI popups (e.g., <select> dropdowns).
     // Using applicationContext causes BadTokenException when the WebView tries to show a Dialog.
@@ -56,6 +79,9 @@ class Ketch private constructor(
 
     // Lock object for synchronization
     private val lock = Any()
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var tapOutsideFallbackRunnable: Runnable? = null
 
     /**
      * Retrieve a String value from the preferences.
@@ -118,20 +144,172 @@ class Ketch private constructor(
                 null,
                 emptyList(),
                 null,
-                ketchUrl,
+                effectiveKetchUrl,
                 logLevel,
                 age,
                 ageLower,
                 ageUpper,
                 bottomPadding,
                 topPadding,
-                cssStyle
+                cssStyle,
+                webResourceUrlOverrides,
             )
             true
         } else {
             false
         }
     }
+
+    /** CDN region used for headless and WebView API calls. */
+    fun getDataCenter(): KetchDataCenter = dataCenter
+
+    /**
+     * Redirect exact-match WebView resource URLs (e.g. UAT tag scripts) to local dev servers.
+     * Android uses native [WebViewClient.shouldInterceptRequest]; JS hook is also embedded in index HTML.
+     */
+    fun setWebResourceUrlOverrides(overrides: Map<String, String>) {
+        webResourceUrlOverrides = overrides.toMap()
+        activeWebView?.setWebResourceUrlOverrides(webResourceUrlOverrides)
+    }
+
+    /** GeoIP / jurisdiction hint (`GET /ip`). */
+    fun fetchLocation(callback: (Result<LocationResponse>) -> Unit) {
+        headlessApiClient.fetchLocation(callback)
+    }
+
+    suspend fun fetchLocation(): LocationResponse = headlessApiClient.fetchLocation()
+
+    /** Minimal config (`GET .../boot.json`). */
+    fun fetchBootstrapConfiguration(
+        callback: (Result<HeadlessConfiguration>) -> Unit,
+    ) {
+        headlessApiClient.fetchBootstrapConfiguration(orgCode, property, callback)
+    }
+
+    suspend fun fetchBootstrapConfiguration(): HeadlessConfiguration =
+        headlessApiClient.fetchBootstrapConfiguration(orgCode, property)
+
+    /** Full config with optional env / jurisdiction / language and hash query param. */
+    fun fetchFullConfiguration(
+        request: FullConfigurationRequest,
+        callback: (Result<HeadlessConfiguration>) -> Unit,
+    ) {
+        headlessApiClient.fetchFullConfiguration(request, callback)
+    }
+
+    suspend fun fetchFullConfiguration(request: FullConfigurationRequest): HeadlessConfiguration =
+        headlessApiClient.fetchFullConfiguration(request)
+
+    /** Server consent including `protocols` (`POST .../consent/{org}/get`). */
+    fun fetchConsent(
+        config: ConsentConfig,
+        callback: (Result<Consent>) -> Unit,
+    ) {
+        headlessApiClient.fetchConsent(config, callback)
+    }
+
+    suspend fun fetchConsent(config: ConsentConfig): Consent =
+        headlessApiClient.fetchConsent(config)
+
+    /** Protocol strings only (same endpoint as fetchConsent). */
+    fun fetchProtocols(
+        config: ConsentConfig,
+        callback: (Result<Consent>) -> Unit,
+    ) {
+        headlessApiClient.fetchProtocols(config, callback)
+    }
+
+    suspend fun fetchProtocols(config: ConsentConfig): Consent =
+        headlessApiClient.fetchProtocols(config)
+
+    /** Updates consent; returns server response with computed `protocols`. */
+    fun setConsent(
+        update: ConsentUpdate,
+        callback: (Result<Consent>) -> Unit,
+    ) {
+        headlessApiClient.setConsent(update.withoutProtocols(), callback)
+    }
+
+    suspend fun setConsent(update: ConsentUpdate): Consent =
+        headlessApiClient.setConsent(update.withoutProtocols())
+
+    /** Invokes a data subject right (`POST .../rights/{org}/invoke`). */
+    fun invokeRight(
+        request: InvokeRightRequest,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        headlessApiClient.invokeRight(request, callback)
+    }
+
+    suspend fun invokeRight(request: InvokeRightRequest) = headlessApiClient.invokeRight(request)
+
+    /** Gets profile preferences (`POST .../profile/{org}/get`). */
+    fun getProfile(
+        request: GetProfileRequest,
+        callback: (Result<GetProfileResponse>) -> Unit,
+    ) {
+        headlessApiClient.getProfile(request, callback)
+    }
+
+    suspend fun getProfile(request: GetProfileRequest): GetProfileResponse =
+        headlessApiClient.getProfile(request)
+
+    /** Updates profile preferences (`POST .../profile/{org}/put`). */
+    fun putProfile(
+        request: PutProfileRequest,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        headlessApiClient.putProfile(request, callback)
+    }
+
+    suspend fun putProfile(request: PutProfileRequest) = headlessApiClient.putProfile(request)
+
+    /** Gets subscription topics/controls (`POST .../subscriptions/{org}/get`). */
+    fun getSubscriptions(
+        request: SubscriptionsRequest,
+        callback: (Result<SubscriptionsResponse>) -> Unit,
+    ) {
+        headlessApiClient.getSubscriptions(request, callback)
+    }
+
+    suspend fun getSubscriptions(request: SubscriptionsRequest): SubscriptionsResponse =
+        headlessApiClient.getSubscriptions(request)
+
+    /** Updates subscription topics/controls (`POST .../subscriptions/{org}/update`). */
+    fun setSubscriptions(
+        request: SubscriptionsRequest,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        headlessApiClient.setSubscriptions(request, callback)
+    }
+
+    suspend fun setSubscriptions(request: SubscriptionsRequest) =
+        headlessApiClient.setSubscriptions(request)
+
+    fun fetchSubscriptionsConfiguration(
+        request: SubscriptionConfigurationRequest,
+        callback: (Result<SubscriptionConfiguration>) -> Unit,
+    ) {
+        headlessApiClient.fetchSubscriptionsConfiguration(request, callback)
+    }
+
+    suspend fun fetchSubscriptionsConfiguration(
+        request: SubscriptionConfigurationRequest,
+    ): SubscriptionConfiguration = headlessApiClient.fetchSubscriptionsConfiguration(request)
+
+    fun preferenceQRUrl(request: PreferenceQRRequest): String =
+        headlessApiClient.preferenceQRUrl(request)
+
+    fun webReport(
+        channel: String,
+        request: WebReportRequest,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        headlessApiClient.webReport(channel, request, callback)
+    }
+
+    suspend fun webReport(channel: String, request: WebReportRequest) =
+        headlessApiClient.webReport(channel, request)
 
     /**
      * Display the consent, adding the fragment dialog to the given FragmentManager.
@@ -149,6 +327,15 @@ class Ketch private constructor(
             return false
         }
 
+        activeWebView?.let { webView ->
+            Log.d(TAG, "showConsent on existing WebView")
+            webView.evaluateJavascript(
+                "(function(){try{window.ketch('showConsent');return 'ok';}catch(e){return String(e);}})()"
+            ) { result -> Log.d(TAG, "showConsent JS result: $result") }
+            webView.requestShowConsent(forceImmediate = true)
+            return true
+        }
+
         val webView = createWebView(shouldRetry, synchronousPreferences)
         return if (webView != null) {
             webView.load(
@@ -162,15 +349,17 @@ class Ketch private constructor(
                 KetchWebView.ExperienceType.CONSENT,
                 emptyList(),
                 null,
-                ketchUrl,
+                effectiveKetchUrl,
                 logLevel,
                 age,
                 ageLower,
                 ageUpper,
                 bottomPadding,
                 topPadding,
-                cssStyle
+                cssStyle,
+                webResourceUrlOverrides,
             )
+            webView.requestShowConsent(forceImmediate = true)
             true
         } else {
             false
@@ -206,14 +395,15 @@ class Ketch private constructor(
                 KetchWebView.ExperienceType.PREFERENCES,
                 emptyList(),
                 null,
-                ketchUrl,
+                effectiveKetchUrl,
                 logLevel,
                 age,
                 ageLower,
                 ageUpper,
                 bottomPadding,
                 topPadding,
-                cssStyle
+                cssStyle,
+                webResourceUrlOverrides,
             )
             true
         } else {
@@ -254,14 +444,15 @@ class Ketch private constructor(
                 KetchWebView.ExperienceType.PREFERENCES,
                 tabs,
                 tab,
-                ketchUrl,
+                effectiveKetchUrl,
                 logLevel,
                 age,
                 ageLower,
                 ageUpper,
                 bottomPadding,
                 topPadding,
-                cssStyle
+                cssStyle,
+                webResourceUrlOverrides,
             )
             true
         } else {
@@ -273,7 +464,22 @@ class Ketch private constructor(
      * Dismiss the dialog
      */
     fun dismissDialog() {
+        dismissExperience(HideExperienceStatus.Close, "dismissDialog")
+    }
+
+    private fun cancelTapOutsideFallback() {
+        tapOutsideFallbackRunnable?.let { mainHandler.removeCallbacks(it) }
+        tapOutsideFallbackRunnable = null
+    }
+
+    private fun notifyDismiss(source: String, status: HideExperienceStatus) {
+        Log.d(TAG, "onDismiss source=$source status=${status.name}")
+        listener?.onDismiss(status)
+    }
+
+    private fun dismissExperience(status: HideExperienceStatus, source: String) {
         synchronized(lock) {
+            cancelTapOutsideFallback()
             val fragment = findDialogFragment()
             if (fragment != null) {
                 try {
@@ -284,9 +490,34 @@ class Ketch private constructor(
                     cleanupWebView()
                     isShowingExperience = false
                     activeDialogFragment = null
-                    this@Ketch.listener?.onDismiss(HideExperienceStatus.None)
+                    notifyDismiss(source, status)
                 }
+            } else {
+                cleanupWebView()
+                isShowingExperience = false
+                notifyDismiss(source, status)
             }
+        }
+    }
+
+    private fun scheduleTapOutsideFallback() {
+        cancelTapOutsideFallback()
+        tapOutsideFallbackRunnable = Runnable {
+            dismissExperience(HideExperienceStatus.Close, "tapOutsideTimeout")
+        }.also {
+            mainHandler.postDelayed(it, TAP_OUTSIDE_FALLBACK_MS)
+        }
+    }
+
+    private fun handleTapOutside() {
+        Log.d(TAG, "onDismiss source=tapOutside delegating to web")
+        val webView = activeWebView
+        if (webView == null) {
+            dismissExperience(HideExperienceStatus.Close, "tapOutsideNoWebView")
+            return
+        }
+        webView.requestWebDismiss {
+            scheduleTapOutsideFallback()
         }
     }
 
@@ -392,7 +623,8 @@ class Ketch private constructor(
             if (existingFragment != null) {
                 try {
                     (existingFragment as? KetchDialogFragment)?.dismissAllowingStateLoss()
-                    this@Ketch.listener?.onDismiss(HideExperienceStatus.None)
+                    Log.d(TAG, "onDismiss source=initCleanup status=Close")
+                    this@Ketch.listener?.onDismiss(HideExperienceStatus.Close)
                 } catch (e: Exception) {
                     Log.e(TAG, "Error dismissing existing dialog in init: ${e.message}")
                 }
@@ -428,6 +660,7 @@ class Ketch private constructor(
             // FragmentManager would also be invalid at that point.
             val webViewContext = activityContext.get() ?: context
             val webView = KetchWebView(webViewContext, shouldRetry)
+            webView.setWebResourceUrlOverrides(webResourceUrlOverrides)
 
             // Enable debug mode
             if (logLevel === LogLevel.DEBUG) {
@@ -437,13 +670,24 @@ class Ketch private constructor(
             webView.listener = object : KetchWebView.WebViewListener {
 
                 private var config: KetchConfig? = null
-                private var showConsent: Boolean = false
+                private var showConsentPending = false
+                private var allowShowBeforeConfig = false
+
+                override fun requestShowConsent(forceImmediate: Boolean) {
+                    if (forceImmediate) {
+                        allowShowBeforeConfig = true
+                    }
+                    showConsent()
+                }
 
                 override fun showConsent() {
-                    if (config == null) {
-                        showConsent = true
+                    if (config == null && !allowShowBeforeConfig) {
+                        Log.d(TAG, "showConsent deferred until config loads")
+                        showConsentPending = true
                         return
                     }
+                    allowShowBeforeConfig = false
+                    showConsentPending = false
                     showConsentPopup()
                 }
 
@@ -499,13 +743,15 @@ class Ketch private constructor(
 
                 override fun onConfigUpdated(config: KetchConfig?) {
                     this.config = config
-
                     this@Ketch.listener?.onConfigUpdated(config)
-
-                    if (!showConsent) {
-                        return
+                    if (showConsentPending) {
+                        showConsentPending = false
+                        showConsentPopup()
                     }
-                    showConsentPopup()
+                }
+
+                override fun onConfigDebugInfo(configSummary: String, purposesSummary: String) {
+                    this@Ketch.listener?.onConfigDebugInfo(configSummary, purposesSummary)
                 }
 
                 override fun onEnvironmentUpdated(environment: String?) {
@@ -540,28 +786,8 @@ class Ketch private constructor(
                     }
                 }
 
-                override fun onClose(status: HideExperienceStatus) {
-                    // Dismiss dialog fragment safely
-                    synchronized(lock) {
-                        val fragment = findDialogFragment()
-                        if (fragment != null) {
-                            try {
-                                (fragment as? KetchDialogFragment)?.dismissAllowingStateLoss()
-                                this@Ketch.listener?.onDismiss(status)
-                            } catch (e: Exception) {
-                                Log.e(TAG, "Error dismissing dialog: ${e.message}")
-                                // Ensure state and WebView are cleaned up even if dismissal fails
-                                cleanupWebView()
-                                isShowingExperience = false
-                                this@Ketch.listener?.onDismiss(status)
-                            }
-                        } else {
-                            // Even if fragment isn't found, clean up and reset state
-                            cleanupWebView()
-                            isShowingExperience = false
-                            this@Ketch.listener?.onDismiss(status)
-                        }
-                    }
+                override fun onClose(status: HideExperienceStatus, source: String) {
+                    dismissExperience(status, source)
                 }
 
                 override fun onWillShowExperience(experienceType: WillShowExperienceType) {
@@ -573,22 +799,7 @@ class Ketch private constructor(
                 }
 
                 override fun onTapOutside() {
-                    // Dismiss dialog fragment safely
-                    synchronized(lock) {
-                        val fragment = findDialogFragment()
-                        if (fragment != null) {
-                            try {
-                                (fragment as? KetchDialogFragment)?.dismissAllowingStateLoss()
-                                this@Ketch.listener?.onDismiss(HideExperienceStatus.None)
-                            } catch (e: Exception) {
-                                Log.e(TAG, "Error dismissing dialog on tap outside: ${e.message}")
-                                // Ensure state and WebView are cleaned up even if dismissal fails
-                                cleanupWebView()
-                                isShowingExperience = false
-                                this@Ketch.listener?.onDismiss(HideExperienceStatus.None)
-                            }
-                        }
-                    }
+                    handleTapOutside()
                 }
 
                 private fun showConsentPopup() {
@@ -612,6 +823,7 @@ class Ketch private constructor(
 
                             fragmentManager.get()?.let { fm ->
                                 if (!fm.isDestroyed) {
+                                    Log.d(TAG, "showConsentPopup: showing dialog")
                                     dialog.show(manager = fm)
                                     isShowingExperience = true
                                     this@Ketch.listener?.onShow()
@@ -627,11 +839,10 @@ class Ketch private constructor(
                             }
                         } catch (e: Exception) {
                             isShowingExperience = false
+                            showConsentPending = false
                             Log.e(TAG, "Error showing dialog: ${e.message}")
                             this@Ketch.listener?.onError("Error showing dialog: ${e.message}")
                         }
-
-                        showConsent = false
                     }
                 }
 
@@ -643,7 +854,7 @@ class Ketch private constructor(
                             }
 
                             ContentDisplay.Banner -> {
-                                it.theme?.modal?.container?.backdrop?.disableContentInteractions == true
+                                it.theme?.banner?.container?.backdrop?.disableContentInteractions == true
                             }
                         }
                     } ?: false
@@ -699,6 +910,11 @@ class Ketch private constructor(
          * Called when the config is updated
          */
         fun onConfigUpdated(config: KetchConfig?)
+
+        /**
+         * Debug summary parsed from raw config.json (purposes, experiences, env).
+         */
+        fun onConfigDebugInfo(configSummary: String, purposesSummary: String) {}
 
         /**
          * Called when the environment is updated.
@@ -758,6 +974,7 @@ class Ketch private constructor(
 
     companion object {
         val TAG = Ketch::class.java.simpleName
+        private const val TAP_OUTSIDE_FALLBACK_MS = 2000L
         fun create(
             context: Context,
             fragmentManager: FragmentManager,
@@ -766,7 +983,9 @@ class Ketch private constructor(
             environment: String?,
             listener: Listener?,
             ketchUrl: String?,
+            dataCenter: KetchDataCenter = KetchDataCenter.US,
             logLevel: LogLevel,
+            webResourceUrlOverrides: Map<String, String> = emptyMap(),
         ) = Ketch(
             context,
             WeakReference(fragmentManager),
@@ -775,7 +994,13 @@ class Ketch private constructor(
             environment,
             listener,
             ketchUrl,
-            logLevel
+            dataCenter,
+            logLevel,
+            HeadlessApiClient(dataCenter),
+            webResourceUrlOverrides,
         )
     }
 }
+
+private fun ConsentUpdate.withoutProtocols(): ConsentUpdate =
+    copy(protocols = null)

--- a/ketchsdk/src/main/java/com/ketch/android/KetchSdk.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/KetchSdk.kt
@@ -2,6 +2,24 @@ package com.ketch.android
 
 import android.content.Context
 import androidx.fragment.app.FragmentManager
+import com.ketch.android.api.HeadlessApiClient
+import com.ketch.android.api.KetchDataCenter
+import com.ketch.android.data.Consent
+import com.ketch.android.data.ConsentConfig
+import com.ketch.android.data.ConsentUpdate
+import com.ketch.android.data.FullConfigurationRequest
+import com.ketch.android.data.GetProfileRequest
+import com.ketch.android.data.GetProfileResponse
+import com.ketch.android.data.HeadlessConfiguration
+import com.ketch.android.data.InvokeRightRequest
+import com.ketch.android.data.LocationResponse
+import com.ketch.android.data.PreferenceQRRequest
+import com.ketch.android.data.PutProfileRequest
+import com.ketch.android.data.SubscriptionConfiguration
+import com.ketch.android.data.SubscriptionConfigurationRequest
+import com.ketch.android.data.SubscriptionsRequest
+import com.ketch.android.data.SubscriptionsResponse
+import com.ketch.android.data.WebReportRequest
 
 /**
  * Factory to create the Ketch object.
@@ -13,8 +31,8 @@ import androidx.fragment.app.FragmentManager
  *               PROPERTY,
  *               ENVIRONMENT,
  *               listener,
- *               TEST_URL,
- *               Ketch.LogLevel.DEBUG
+ *               dataCenter = KetchDataCenter.US,
+ *               logLevel = Ketch.LogLevel.DEBUG
  *           )
  **/
 object KetchSdk {
@@ -27,8 +45,10 @@ object KetchSdk {
      * @param property - the property name
      * @param environment - the environment name.
      * @param listener - Ketch.Listener. Optional
-     * @param ketchUrl - Overrides the ketch url. Optional
+     * @param ketchUrl - Overrides the ketch url. Optional; defaults to [dataCenter] base URL.
+     * @param dataCenter - CDN region for headless and WebView API calls. Default US.
      * @param logLevel - the log level, can be TRACE, DEBUG, INFO, WARN, ERROR. Default is ERROR
+     * @param webResourceUrlOverrides - Map of exact source URL to local replacement URL for WebView resources (e.g. tag scripts).
      */
     fun create(
         context: Context,
@@ -38,7 +58,9 @@ object KetchSdk {
         environment: String? = null,
         listener: Ketch.Listener? = null,
         ketchUrl: String? = null,
-        logLevel: Ketch.LogLevel = Ketch.LogLevel.ERROR
+        dataCenter: KetchDataCenter = KetchDataCenter.US,
+        logLevel: Ketch.LogLevel = Ketch.LogLevel.ERROR,
+        webResourceUrlOverrides: Map<String, String> = emptyMap(),
     ): Ketch {
         return Ketch.create(
             context = context,
@@ -48,7 +70,130 @@ object KetchSdk {
             environment = environment,
             listener = listener,
             ketchUrl = ketchUrl,
-            logLevel = logLevel
+            dataCenter = dataCenter,
+            logLevel = logLevel,
+            webResourceUrlOverrides = webResourceUrlOverrides,
         )
+    }
+
+    // MARK: - Headless API (static, web/v3)
+
+    /** GeoIP / jurisdiction hint (`GET /ip`). */
+    fun fetchLocation(
+        dataCenter: KetchDataCenter = KetchDataCenter.US,
+        callback: (Result<LocationResponse>) -> Unit,
+    ) {
+        HeadlessApiClient(dataCenter).fetchLocation(callback)
+    }
+
+    /** Minimal config (`GET .../boot.json`). */
+    fun fetchBootstrapConfiguration(
+        organization: String,
+        property: String,
+        dataCenter: KetchDataCenter = KetchDataCenter.US,
+        callback: (Result<HeadlessConfiguration>) -> Unit,
+    ) {
+        HeadlessApiClient(dataCenter).fetchBootstrapConfiguration(organization, property, callback)
+    }
+
+    /** Full config with optional env / jurisdiction / language and hash query param. */
+    fun fetchFullConfiguration(
+        request: FullConfigurationRequest,
+        dataCenter: KetchDataCenter = KetchDataCenter.US,
+        callback: (Result<HeadlessConfiguration>) -> Unit,
+    ) {
+        HeadlessApiClient(dataCenter).fetchFullConfiguration(request, callback)
+    }
+
+    /** Server consent including `protocols` (`POST .../consent/{org}/get`). */
+    fun fetchConsent(
+        config: ConsentConfig,
+        dataCenter: KetchDataCenter = KetchDataCenter.US,
+        callback: (Result<Consent>) -> Unit,
+    ) {
+        HeadlessApiClient(dataCenter).fetchConsent(config, callback)
+    }
+
+    /** Protocol strings only (same endpoint as fetchConsent). */
+    fun fetchProtocols(
+        config: ConsentConfig,
+        dataCenter: KetchDataCenter = KetchDataCenter.US,
+        callback: (Result<Consent>) -> Unit,
+    ) {
+        HeadlessApiClient(dataCenter).fetchProtocols(config, callback)
+    }
+
+    /** Updates consent; returns server response with computed `protocols`. */
+    fun setConsent(
+        update: ConsentUpdate,
+        dataCenter: KetchDataCenter = KetchDataCenter.US,
+        callback: (Result<Consent>) -> Unit,
+    ) {
+        HeadlessApiClient(dataCenter).setConsent(
+            update.copy(protocols = null),
+            callback,
+        )
+    }
+
+    fun invokeRight(
+        request: InvokeRightRequest,
+        dataCenter: KetchDataCenter = KetchDataCenter.US,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        HeadlessApiClient(dataCenter).invokeRight(request, callback)
+    }
+
+    fun getProfile(
+        request: GetProfileRequest,
+        dataCenter: KetchDataCenter = KetchDataCenter.US,
+        callback: (Result<GetProfileResponse>) -> Unit,
+    ) {
+        HeadlessApiClient(dataCenter).getProfile(request, callback)
+    }
+
+    fun putProfile(
+        request: PutProfileRequest,
+        dataCenter: KetchDataCenter = KetchDataCenter.US,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        HeadlessApiClient(dataCenter).putProfile(request, callback)
+    }
+
+    fun getSubscriptions(
+        request: SubscriptionsRequest,
+        dataCenter: KetchDataCenter = KetchDataCenter.US,
+        callback: (Result<SubscriptionsResponse>) -> Unit,
+    ) {
+        HeadlessApiClient(dataCenter).getSubscriptions(request, callback)
+    }
+
+    fun setSubscriptions(
+        request: SubscriptionsRequest,
+        dataCenter: KetchDataCenter = KetchDataCenter.US,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        HeadlessApiClient(dataCenter).setSubscriptions(request, callback)
+    }
+
+    fun fetchSubscriptionsConfiguration(
+        request: SubscriptionConfigurationRequest,
+        dataCenter: KetchDataCenter = KetchDataCenter.US,
+        callback: (Result<SubscriptionConfiguration>) -> Unit,
+    ) {
+        HeadlessApiClient(dataCenter).fetchSubscriptionsConfiguration(request, callback)
+    }
+
+    fun preferenceQRUrl(
+        request: PreferenceQRRequest,
+        dataCenter: KetchDataCenter = KetchDataCenter.US,
+    ): String = HeadlessApiClient(dataCenter).preferenceQRUrl(request)
+
+    fun webReport(
+        channel: String,
+        request: WebReportRequest,
+        dataCenter: KetchDataCenter = KetchDataCenter.US,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        HeadlessApiClient(dataCenter).webReport(channel, request, callback)
     }
 }

--- a/ketchsdk/src/main/java/com/ketch/android/api/HeadlessApiClient.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/api/HeadlessApiClient.kt
@@ -1,0 +1,449 @@
+package com.ketch.android.api
+
+import com.google.gson.Gson
+import com.ketch.android.data.Consent
+import com.ketch.android.data.ConsentConfig
+import com.ketch.android.data.ConsentUpdate
+import com.ketch.android.data.FullConfigurationRequest
+import com.ketch.android.data.GetProfileRequest
+import com.ketch.android.data.GetProfileResponse
+import com.ketch.android.data.HeadlessConfiguration
+import com.ketch.android.data.HeadlessException
+import com.ketch.android.data.InvokeRightRequest
+import com.ketch.android.data.LocationResponse
+import com.ketch.android.data.PreferenceQRRequest
+import com.ketch.android.data.PutProfileRequest
+import com.ketch.android.data.SubscriptionConfiguration
+import com.ketch.android.data.SubscriptionConfigurationRequest
+import com.ketch.android.data.SubscriptionsRequest
+import com.ketch.android.data.SubscriptionsResponse
+import com.ketch.android.data.WebReportRequest
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+
+/**
+ * Native HTTP client mirroring ketch-tag [KetchWebAPI] (web/v3).
+ */
+class HeadlessApiClient(
+    dataCenter: KetchDataCenter = KetchDataCenter.US,
+    baseUrl: String? = null,
+    private val okHttpClient: OkHttpClient = OkHttpClient(),
+    private val gson: Gson = Gson(),
+) {
+    private val baseUrl = baseUrl ?: dataCenter.baseUrl
+    private val jsonMediaType = "application/json".toMediaType()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    fun fetchLocation(callback: (Result<LocationResponse>) -> Unit) {
+        launchAsync(callback) { fetchLocation() }
+    }
+
+    suspend fun fetchLocation(): LocationResponse = withContext(Dispatchers.IO) {
+        get("/ip", LocationResponse::class.java)
+    }
+
+    fun fetchBootstrapConfiguration(
+        organization: String,
+        property: String,
+        callback: (Result<HeadlessConfiguration>) -> Unit,
+    ) {
+        launchAsync(callback) { fetchBootstrapConfiguration(organization, property) }
+    }
+
+    suspend fun fetchBootstrapConfiguration(
+        organization: String,
+        property: String,
+    ): HeadlessConfiguration = withContext(Dispatchers.IO) {
+        get("/config/$organization/$property/boot.json", HeadlessConfiguration::class.java)
+    }
+
+    fun fetchFullConfiguration(
+        request: FullConfigurationRequest,
+        callback: (Result<HeadlessConfiguration>) -> Unit,
+    ) {
+        launchAsync(callback) { fetchFullConfiguration(request) }
+    }
+
+    suspend fun fetchFullConfiguration(request: FullConfigurationRequest): HeadlessConfiguration =
+        withContext(Dispatchers.IO) {
+            var path = "/config/${request.organizationCode}/${request.propertyCode}"
+            if (request.environmentCode != null &&
+                request.jurisdictionCode != null &&
+                request.languageCode != null
+            ) {
+                path += "/${request.environmentCode}/${request.jurisdictionCode}/${request.languageCode}"
+            }
+            path += "/config.json"
+            val query = request.hash?.let { mapOf("hash" to it) } ?: emptyMap()
+            get(path, HeadlessConfiguration::class.java, query)
+        }
+
+    fun fetchConsent(
+        config: ConsentConfig,
+        callback: (Result<Consent>) -> Unit,
+    ) {
+        launchAsync(callback) { fetchConsent(config) }
+    }
+
+    suspend fun fetchConsent(config: ConsentConfig): Consent = withContext(Dispatchers.IO) {
+        val path = "/consent/${config.organizationCode}/get"
+        postConsent(path, ConsentConfigPayload.from(config), config)
+    }
+
+    fun fetchProtocols(
+        config: ConsentConfig,
+        callback: (Result<Consent>) -> Unit,
+    ) {
+        launchAsync(callback) { fetchProtocols(config) }
+    }
+
+    suspend fun fetchProtocols(config: ConsentConfig): Consent = withContext(Dispatchers.IO) {
+        val response = fetchConsent(config)
+        if (response.protocols.isNullOrEmpty()) {
+            Consent(
+                purposes = response.purposes,
+                vendors = response.vendors,
+                protocols = null,
+            )
+        } else {
+            response
+        }
+    }
+
+    fun setConsent(
+        update: ConsentUpdate,
+        callback: (Result<Consent>) -> Unit,
+    ) {
+        launchAsync(callback) { setConsent(update) }
+    }
+
+    suspend fun setConsent(update: ConsentUpdate): Consent = withContext(Dispatchers.IO) {
+        val path = "/consent/${update.organizationCode}/update"
+        postSetConsent(path, SetConsentPayload.from(update), update)
+    }
+
+    fun invokeRight(
+        request: InvokeRightRequest,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        launchAsync(callback) { invokeRight(request) }
+    }
+
+    suspend fun invokeRight(request: InvokeRightRequest): Unit = withContext(Dispatchers.IO) {
+        postVoid("/rights/${request.organizationCode}/invoke", request)
+    }
+
+    fun getProfile(
+        request: GetProfileRequest,
+        callback: (Result<GetProfileResponse>) -> Unit,
+    ) {
+        launchAsync(callback) { getProfile(request) }
+    }
+
+    suspend fun getProfile(request: GetProfileRequest): GetProfileResponse = withContext(Dispatchers.IO) {
+        post("/profile/${request.organizationCode}/get", request, GetProfileResponse::class.java)
+    }
+
+    fun putProfile(
+        request: PutProfileRequest,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        launchAsync(callback) { putProfile(request) }
+    }
+
+    suspend fun putProfile(request: PutProfileRequest): Unit = withContext(Dispatchers.IO) {
+        postVoid("/profile/${request.organizationCode}/put", request)
+    }
+
+    fun getSubscriptions(
+        request: SubscriptionsRequest,
+        callback: (Result<SubscriptionsResponse>) -> Unit,
+    ) {
+        launchAsync(callback) { getSubscriptions(request) }
+    }
+
+    suspend fun getSubscriptions(request: SubscriptionsRequest): SubscriptionsResponse =
+        withContext(Dispatchers.IO) {
+            post("/subscriptions/${request.organizationCode}/get", request, SubscriptionsResponse::class.java)
+        }
+
+    fun setSubscriptions(
+        request: SubscriptionsRequest,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        launchAsync(callback) { setSubscriptions(request) }
+    }
+
+    suspend fun setSubscriptions(request: SubscriptionsRequest): Unit = withContext(Dispatchers.IO) {
+        postVoid("/subscriptions/${request.organizationCode}/update", request)
+    }
+
+    fun fetchSubscriptionsConfiguration(
+        request: SubscriptionConfigurationRequest,
+        callback: (Result<SubscriptionConfiguration>) -> Unit,
+    ) {
+        launchAsync(callback) { fetchSubscriptionsConfiguration(request) }
+    }
+
+    suspend fun fetchSubscriptionsConfiguration(
+        request: SubscriptionConfigurationRequest,
+    ): SubscriptionConfiguration = withContext(Dispatchers.IO) {
+        val path = "/config/${request.organizationCode}/${request.propertyCode}/${request.languageCode}/${request.experienceCode}/subscriptions.json"
+        get(path, SubscriptionConfiguration::class.java)
+    }
+
+    fun preferenceQRUrl(request: PreferenceQRRequest): String {
+        val query = linkedMapOf<String, String>()
+        request.environmentCode?.let { query["env"] = it }
+        request.imageSize?.let { query["size"] = it.toString() }
+        request.path?.let { query["path"] = it }
+        request.backgroundColor?.let { query["bgcolor"] = it }
+        request.foregroundColor?.let { query["fgcolor"] = it }
+        query.putAll(request.parameters)
+        return buildUrl(
+            "/qr/${request.organizationCode}/${request.propertyCode}/preferences.png",
+            query,
+        )
+    }
+
+    fun webReport(
+        channel: String,
+        request: WebReportRequest,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        launchAsync(callback) { webReport(channel, request) }
+    }
+
+    suspend fun webReport(channel: String, request: WebReportRequest): Unit =
+        withContext(Dispatchers.IO) {
+            postVoid("/report/$channel", request)
+        }
+
+    /** Builds an absolute CDN URL for unit tests and debugging. */
+    fun buildUrl(path: String, query: Map<String, String> = emptyMap()): String {
+        val normalized = if (path.startsWith("/")) path else "/$path"
+        val url = baseUrl.trimEnd('/') + normalized
+        if (query.isEmpty()) {
+            return url
+        }
+        val httpUrl = url.toHttpUrl().newBuilder()
+        query.forEach { (key, value) -> httpUrl.addQueryParameter(key, value) }
+        return httpUrl.build().toString()
+    }
+
+    private fun <T> get(path: String, type: Class<T>, query: Map<String, String> = emptyMap()): T {
+        val url = buildUrl(path, query)
+        val request = Request.Builder()
+            .url(url)
+            .header("Accept", "application/json")
+            .get()
+            .build()
+        return execute(request, type)
+    }
+
+    private fun <T> execute(request: Request, type: Class<T>): T {
+        try {
+            okHttpClient.newCall(request).execute().use { response ->
+                val body = response.body?.string().orEmpty()
+                if (!response.isSuccessful) {
+                    throw HeadlessException("HTTP ${response.code} for ${request.url}")
+                }
+                if (body.isBlank() || body == "null") {
+                    throw HeadlessException("Empty response for ${request.url}")
+                }
+                return gson.fromJson(body, type)
+                    ?: throw HeadlessException("Failed to decode response for ${request.url}")
+            }
+        } catch (error: HeadlessException) {
+            throw error
+        } catch (error: IOException) {
+            throw HeadlessException("Network error for ${request.url}", error)
+        }
+    }
+
+    private fun postConsent(path: String, body: ConsentConfigPayload, config: ConsentConfig): Consent {
+        val request = buildConsentPostRequest(path, body)
+        return executeConsentFetch(request, config)
+    }
+
+    private fun postSetConsent(path: String, body: SetConsentPayload, fallback: ConsentUpdate): Consent {
+        val request = buildConsentPostRequest(path, body)
+        return executeConsentSet(request, fallback)
+    }
+
+    private fun buildConsentPostRequest(path: String, body: Any): Request {
+        val json = gson.toJson(body)
+        return Request.Builder()
+            .url(buildUrl(path))
+            .header("Accept", "application/json")
+            .header("Content-Type", "application/json")
+            .post(json.toRequestBody(jsonMediaType))
+            .build()
+    }
+
+    private fun executeConsentFetch(request: Request, config: ConsentConfig): Consent {
+        try {
+            okHttpClient.newCall(request).execute().use { response ->
+                val body = response.body?.string().orEmpty()
+                if (!response.isSuccessful) {
+                    throw HeadlessException("HTTP ${response.code} for ${request.url}")
+                }
+                if (body.isBlank() || body == "null") {
+                    return emptyConsent(config)
+                }
+                val decoded = decodeConsent(body)
+                if (decoded != null && hasUsableConsentFields(decoded)) {
+                    return decoded
+                }
+                return emptyConsent(config)
+            }
+        } catch (error: HeadlessException) {
+            throw error
+        } catch (error: IOException) {
+            throw HeadlessException("Network error for ${request.url}", error)
+        }
+    }
+
+    private fun executeConsentSet(request: Request, fallback: ConsentUpdate): Consent {
+        try {
+            okHttpClient.newCall(request).execute().use { response ->
+                val body = response.body?.string().orEmpty()
+                if (!response.isSuccessful) {
+                    throw HeadlessException("HTTP ${response.code} for ${request.url}")
+                }
+                val decoded = decodeConsent(body)
+                if (decoded != null && hasUsableConsentFields(decoded)) {
+                    return decoded
+                }
+                return consentFromUpdate(fallback)
+            }
+        } catch (error: HeadlessException) {
+            throw error
+        } catch (error: IOException) {
+            throw HeadlessException("Network error for ${request.url}", error)
+        }
+    }
+
+    private fun decodeConsent(body: String): Consent? =
+        try {
+            gson.fromJson(body, Consent::class.java)
+        } catch (_: Exception) {
+            null
+        }
+
+    private fun hasUsableConsentFields(consent: Consent): Boolean {
+        if (!consent.purposes.isNullOrEmpty()) return true
+        if (!consent.protocols.isNullOrEmpty()) return true
+        return false
+    }
+
+    private fun <T> post(path: String, body: Any, type: Class<T>): T {
+        val json = gson.toJson(body)
+        val request = Request.Builder()
+            .url(buildUrl(path))
+            .header("Accept", "application/json")
+            .header("Content-Type", "application/json")
+            .post(json.toRequestBody(jsonMediaType))
+            .build()
+        return execute(request, type)
+    }
+
+    private fun postVoid(path: String, body: Any) {
+        val json = gson.toJson(body)
+        val request = Request.Builder()
+            .url(buildUrl(path))
+            .header("Accept", "application/json")
+            .header("Content-Type", "application/json")
+            .post(json.toRequestBody(jsonMediaType))
+            .build()
+        try {
+            okHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw HeadlessException("HTTP ${response.code} for ${request.url}")
+                }
+            }
+        } catch (error: HeadlessException) {
+            throw error
+        } catch (error: IOException) {
+            throw HeadlessException("Network error for ${request.url}", error)
+        }
+    }
+
+    private fun emptyConsent(config: ConsentConfig): Consent =
+        Consent(purposes = emptyMap(), vendors = null, protocols = null)
+
+    private fun consentFromUpdate(update: ConsentUpdate): Consent {
+        val purposes = update.purposes.mapValues { (_, basis) ->
+            basis.allowed.equals("true", ignoreCase = true)
+        }
+        return Consent(purposes = purposes, vendors = update.vendors, protocols = null)
+    }
+
+    private fun <T> launchAsync(
+        callback: (Result<T>) -> Unit,
+        block: suspend () -> T,
+    ) {
+        scope.launch {
+            try {
+                callback(Result.success(block()))
+            } catch (error: HeadlessException) {
+                callback(Result.failure(error))
+            } catch (error: Exception) {
+                callback(Result.failure(HeadlessException(error.message ?: "Headless API error", error)))
+            }
+        }
+    }
+
+    private data class ConsentConfigPayload(
+        val organizationCode: String,
+        val propertyCode: String,
+        val environmentCode: String,
+        val jurisdictionCode: String,
+        val identities: Map<String, String>,
+        val purposes: Map<String, ConsentConfig.PurposeLegalBasis>,
+    ) {
+        companion object {
+            fun from(config: ConsentConfig) = ConsentConfigPayload(
+                organizationCode = config.organizationCode,
+                propertyCode = config.propertyCode,
+                environmentCode = config.environmentCode,
+                jurisdictionCode = config.jurisdictionCode,
+                identities = config.identities,
+                purposes = config.purposes,
+            )
+        }
+    }
+
+    private data class SetConsentPayload(
+        val organizationCode: String,
+        val propertyCode: String,
+        val environmentCode: String,
+        val identities: Map<String, String>,
+        val jurisdictionCode: String,
+        val migrationOption: ConsentUpdate.MigrationOption,
+        val purposes: Map<String, ConsentUpdate.PurposeAllowedLegalBasis>,
+        val vendors: List<String>?,
+    ) {
+        companion object {
+            fun from(update: ConsentUpdate) = SetConsentPayload(
+                organizationCode = update.organizationCode,
+                propertyCode = update.propertyCode,
+                environmentCode = update.environmentCode,
+                identities = update.identities,
+                jurisdictionCode = update.jurisdictionCode,
+                migrationOption = update.migrationOption,
+                purposes = update.purposes,
+                vendors = update.vendors,
+            )
+        }
+    }
+}

--- a/ketchsdk/src/main/java/com/ketch/android/api/KetchDataCenter.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/api/KetchDataCenter.kt
@@ -1,0 +1,10 @@
+package com.ketch.android.api
+
+/**
+ * Ketch CDN region for headless and WebView API calls (matches Flutter / React Native maps).
+ */
+enum class KetchDataCenter(val baseUrl: String) {
+    US("https://global.ketchcdn.com/web/v3"),
+    EU("https://eu.ketchcdn.com/web/v3"),
+    UAT("https://dev.ketchcdn.com/web/v3"),
+}

--- a/ketchsdk/src/main/java/com/ketch/android/data/Events.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/data/Events.kt
@@ -7,6 +7,7 @@ enum class HideExperienceStatus(val value: String?) {
     Close("close"),
     CloseWithoutSettingConsent("closeWithoutSettingConsent"),
     WillNotShow("willNotShow"),
+    SetSubscriptions("setSubscriptions"),
     None(null);
 
     companion object {

--- a/ketchsdk/src/main/java/com/ketch/android/data/HeadlessModels.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/data/HeadlessModels.kt
@@ -1,0 +1,257 @@
+package com.ketch.android.data
+
+import com.google.gson.annotations.SerializedName
+
+/** GeoIP details from `GET /ip` (ketch-types `IPInfo`). */
+data class IPInfo(
+    @SerializedName("ip") val ip: String? = null,
+    @SerializedName("hostname") val hostname: String? = null,
+    @SerializedName("continentCode") val continentCode: String? = null,
+    @SerializedName("continentName") val continentName: String? = null,
+    @SerializedName("countryCode") val countryCode: String? = null,
+    @SerializedName("countryName") val countryName: String? = null,
+    @SerializedName("regionCode") val regionCode: String? = null,
+    @SerializedName("regionName") val regionName: String? = null,
+    @SerializedName("city") val city: String? = null,
+    @SerializedName("postalCode") val postalCode: String? = null,
+    @SerializedName("timezone") val timezone: String? = null,
+)
+
+/** Response from headless `fetchLocation()`. */
+data class LocationResponse(
+    @SerializedName("location") val location: IPInfo? = null,
+)
+
+/** Parameters for v3 `getFullConfiguration` (ketch-types `GetFullConfigurationRequest`). */
+data class FullConfigurationRequest(
+    val organizationCode: String,
+    val propertyCode: String,
+    val environmentCode: String? = null,
+    val jurisdictionCode: String? = null,
+    val languageCode: String? = null,
+    val hash: String? = null,
+)
+
+/** Request body for `POST /consent/{org}/get`. */
+data class ConsentConfig(
+    val organizationCode: String,
+    val propertyCode: String,
+    val environmentCode: String,
+    val jurisdictionCode: String,
+    val identities: Map<String, String>,
+    val purposes: Map<String, PurposeLegalBasis>,
+) {
+    data class PurposeLegalBasis(
+        @SerializedName("legalBasisCode") val legalBasisCode: String,
+    )
+}
+
+/** Request body for `POST /consent/{org}/update`. */
+data class ConsentUpdate(
+    val organizationCode: String,
+    val propertyCode: String,
+    val environmentCode: String,
+    val identities: Map<String, String>,
+    val jurisdictionCode: String,
+    val migrationOption: MigrationOption,
+    val purposes: Map<String, PurposeAllowedLegalBasis>,
+    val vendors: List<String>? = null,
+    val protocols: Map<String, String>? = null,
+) {
+    enum class MigrationOption {
+        @SerializedName("MIGRATE_DEFAULT")
+        MIGRATE_DEFAULT,
+
+        @SerializedName("MIGRATE_NEVER")
+        MIGRATE_NEVER,
+
+        @SerializedName("MIGRATE_FROM_ALLOW")
+        MIGRATE_FROM_ALLOW,
+
+        @SerializedName("MIGRATE_FROM_DENY")
+        MIGRATE_FROM_DENY,
+
+        @SerializedName("MIGRATE_ALWAYS")
+        MIGRATE_ALWAYS,
+    }
+
+    data class PurposeAllowedLegalBasis(
+        @SerializedName("allowed") val allowed: String,
+        @SerializedName("legalBasisCode") val legalBasisCode: String,
+    ) {
+        constructor(allowed: Boolean, legalBasisCode: String) : this(
+            allowed = allowed.toString(),
+            legalBasisCode = legalBasisCode,
+        )
+    }
+}
+
+/** Full configuration from bootstrap / full-config CDN endpoints. */
+data class HeadlessConfiguration(
+    @SerializedName("experiences") val experiences: Experiences? = null,
+    @SerializedName("theme") val theme: KetchTheme? = null,
+    @SerializedName("rights") val rights: List<ConfigurationRight>? = null,
+    @SerializedName("jurisdiction") val jurisdiction: ConfigurationJurisdiction? = null,
+    @SerializedName("purposes") val purposes: List<ConfigurationPurpose>? = null,
+)
+
+data class ConfigurationRight(
+    @SerializedName("code") val code: String? = null,
+    @SerializedName("name") val name: String? = null,
+    @SerializedName("description") val description: String? = null,
+)
+
+data class ConfigurationJurisdiction(
+    @SerializedName("code") val code: String? = null,
+    @SerializedName("defaultJurisdictionCode") val defaultJurisdictionCode: String? = null,
+)
+
+data class ConfigurationPurpose(
+    @SerializedName("code") val code: String? = null,
+    @SerializedName("legalBasisCode") val legalBasisCode: String? = null,
+)
+
+/** ketch-types `DataSubject` */
+data class DataSubject(
+    @SerializedName("email") val email: String,
+    @SerializedName("firstName") val firstName: String,
+    @SerializedName("lastName") val lastName: String,
+    @SerializedName("country") val country: String? = null,
+    @SerializedName("stateRegion") val stateRegion: String? = null,
+    @SerializedName("city") val city: String? = null,
+    @SerializedName("description") val description: String? = null,
+    @SerializedName("phone") val phone: String? = null,
+    @SerializedName("postalCode") val postalCode: String? = null,
+    @SerializedName("addressLine1") val addressLine1: String? = null,
+    @SerializedName("addressLine2") val addressLine2: String? = null,
+)
+
+/** ketch-types `InvokeRightRequest` */
+data class InvokeRightRequest(
+    val organizationCode: String,
+    val propertyCode: String,
+    val environmentCode: String,
+    val identities: Map<String, String>,
+    val jurisdictionCode: String,
+    val rightCode: String,
+    val user: DataSubject,
+    val controllerCode: String? = null,
+    val invokedAt: Long? = null,
+    val recaptchaToken: String? = null,
+    val regionCode: String? = null,
+    val isAuthenticated: Boolean? = null,
+)
+
+/** ketch-types `ProfilePreferencesIdentity` */
+data class ProfilePreferencesIdentity(
+    @SerializedName("identitySpace") val identitySpace: String,
+    @SerializedName("identityValue") val identityValue: String,
+)
+
+/** ketch-types `ProfilePreferencesAttribute` */
+data class ProfilePreferencesAttribute(
+    @SerializedName("attributeCode") val attributeCode: String,
+    @SerializedName("attributeValue") val attributeValue: String? = null,
+    @SerializedName("source") val source: String,
+)
+
+/** ketch-types `ProfilePreferencesContext` */
+data class ProfilePreferencesContext(
+    @SerializedName("source") val source: String,
+    @SerializedName("updatedAt") val updatedAt: Long? = null,
+    @SerializedName("configId") val configId: String? = null,
+)
+
+/** ketch-types `GetProfileRequest` */
+data class GetProfileRequest(
+    val organizationCode: String,
+    val propertyCode: String,
+    val jurisdictionCode: String,
+    val languageCode: String,
+    val identities: List<ProfilePreferencesIdentity>,
+    val controllerCode: String? = null,
+    val environmentCode: String? = null,
+    @SerializedName("accountID") val accountId: String? = null,
+    val regionCode: String? = null,
+)
+
+/** ketch-types `GetProfileResponse` */
+data class GetProfileResponse(
+    val controllerCode: String? = null,
+    val propertyCode: String? = null,
+    val environmentCode: String? = null,
+    val jurisdictionCode: String? = null,
+    val regionCode: String? = null,
+    val attributes: List<ProfilePreferencesAttribute>? = null,
+)
+
+/** ketch-types `PutProfileRequest` */
+data class PutProfileRequest(
+    val organizationCode: String,
+    val propertyCode: String,
+    val jurisdictionCode: String,
+    val languageCode: String,
+    val identities: List<ProfilePreferencesIdentity>,
+    val context: ProfilePreferencesContext,
+    val controllerCode: String? = null,
+    val environmentCode: String? = null,
+    val attributes: List<ProfilePreferencesAttribute>? = null,
+    val accountId: String? = null,
+    val regionCode: String? = null,
+)
+
+/** ketch-types `GetSubscriptionConfigurationRequest` */
+data class SubscriptionConfigurationRequest(
+    val organizationCode: String,
+    val propertyCode: String,
+    val languageCode: String,
+    val experienceCode: String,
+)
+
+/** Subset of ketch-types `SubscriptionConfiguration` */
+data class SubscriptionConfiguration(
+    val identities: Map<String, String>? = null,
+    val controls: List<Map<String, Any>>? = null,
+    val topics: List<Map<String, Any>>? = null,
+)
+
+/** ketch-types `GetPreferenceQRRequest` */
+data class PreferenceQRRequest(
+    val organizationCode: String,
+    val propertyCode: String,
+    val environmentCode: String? = null,
+    val imageSize: Int? = null,
+    val path: String? = null,
+    val backgroundColor: String? = null,
+    val foregroundColor: String? = null,
+    val parameters: Map<String, String> = emptyMap(),
+)
+
+/** ketch-types `WebReportRequest` */
+data class WebReportRequest(
+    val type: String,
+    val age: Int,
+    val url: String,
+    @SerializedName("user_agent") val userAgent: String,
+    val body: Map<String, String>,
+)
+
+/** ketch-types `GetSubscriptionsRequest` / `SetSubscriptionsRequest` */
+data class SubscriptionsRequest(
+    val organizationCode: String,
+    val controllerCode: String? = null,
+    val propertyCode: String? = null,
+    val environmentCode: String? = null,
+    val identities: Map<String, String>? = null,
+    val topics: Map<String, Map<String, String>>? = null,
+    val controls: Map<String, Map<String, String>>? = null,
+    val collectedAt: Long? = null,
+    val jurisdictionCode: String? = null,
+    val regionCode: String? = null,
+)
+
+/** ketch-types `GetSubscriptionsResponse` */
+typealias SubscriptionsResponse = SubscriptionsRequest
+
+/** Errors from native headless HTTP calls. */
+class HeadlessException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/ketchsdk/src/main/java/com/ketch/android/data/Index.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/data/Index.kt
@@ -1,5 +1,7 @@
 package com.ketch.android.data
 
+import com.google.gson.Gson
+
 /*
 * https://global.ketchcdn.com/web/v3//config/ketch_samples/android/boot.js?ketch_log=DEBUG
 *       &ketch_lang=en&ketch_jurisdiction=default&ketch_region=US
@@ -12,7 +14,7 @@ fun getIndexHtml(
     ketchMobileSdkUrl: String,
     language: String? = null,
     jurisdiction: String? = null,
-    identities: String,
+    identities: Map<String, String> = emptyMap(),
     region: String? = null,
     environment: String? = null,
     forceShow: String? = null,
@@ -23,205 +25,383 @@ fun getIndexHtml(
     ageUpper: Int? = null,
     bottomPadding: String = "0px",
     topPadding: String = "0px",
-    cssStyleOverride: String? = null
-) =
-    "<html>\n" +
-            "  <head>\n" +
-            "    <style>\n" +
-            "      body {\n" +
-            "        height: 100dvh;\n" +
-            "        width: 100dvw;\n" +
-            "        min-height: -webkit-fill-available;\n" +
-            "        --safe-area-inset-bottom: $bottomPadding;\n" +
-            "        --safe-area-inset-top: $topPadding;\n" +
-            "      }\n" +
-            "    </style>\n" +
-            (if (cssStyleOverride?.isNotBlank() == true) {
-                "<style>$cssStyleOverride</style>"
-            } else {
-                ""
-            }) +
-            "    <meta\n" +
-            "      name=\"viewport\"\n" +
-            "      content=\"width=device-width, height=device-height, initial-scale=1, viewport-fit=cover\"\n" +
-            "    />\n" +
-            "  </head>\n" +
-            "  <body>\n" +
-            "    <script>\n" +
-            "\n" +
-            "      window.semaphore = window.semaphore || [];\n" +
-            "      window.ketch = function () {\n" +
-            "        window.semaphore.push(arguments);\n" +
-            "      };\n" +
-            "\n" +
-            "      // Simulating events similar to ones coming from lanyard.js\n" +
-            "      // TODO: remove this once JS SDK covers all required events\n" +
-            "      function emitEvent(event, args) {\n" +
-            "        if (\n" +
-            "          window.androidListener ||\n" +
-            "          (window.webkit && window.webkit.messageHandlers) ||\n" +
-            "          (window.ReactNativeWebView && window.ReactNativeWebView.postMessage)\n" +
-            "        ) {\n" +
-            "          const filteredArgs = [];\n" +
-            "          for (const arg of args) {\n" +
-            "            if (arg !== this) {\n" +
-            "              filteredArgs.push(arg);\n" +
-            "            }\n" +
-            "          }\n" +
-            "          let argument;\n" +
-            "          if (\n" +
-            "            filteredArgs.length === 1 &&\n" +
-            "            typeof filteredArgs[0] === 'string'\n" +
-            "          ) {\n" +
-            "            argument = filteredArgs[0];\n" +
-            "          } else if (filteredArgs.length === 1) {\n" +
-            "            argument = JSON.stringify(filteredArgs[0]);\n" +
-            "          } else if (filteredArgs.length > 1) {\n" +
-            "            argument = JSON.stringify(filteredArgs);\n" +
-            "          }\n" +
-            "          if (window.androidListener && event in window.androidListener) {\n" +
-            "            if (filteredArgs.length === 0) {\n" +
-            "              window.androidListener[event]();\n" +
-            "            } else {\n" +
-            "              window.androidListener[event](argument);\n" +
-            "            }\n" +
-            "          } else if (\n" +
-            "            window.webkit &&\n" +
-            "            window.webkit.messageHandlers &&\n" +
-            "            event in window.webkit.messageHandlers\n" +
-            "          ) {\n" +
-            "            window.webkit.messageHandlers[event].postMessage(argument);\n" +
-            "          } else if (window.ReactNativeWebView && window.ReactNativeWebView.postMessage) {\n" +
-            "            window.ReactNativeWebView.postMessage(JSON.stringify({ event, data: argument }))\n" +
-            "          } else {\n" +
-            "            console.warn('Can\\'t pass message to native code because \${event} handler is not registered');\n" +
-            "          }\n" +
-            "        }\n" +
-            "      }\n" +
-            "\n" +
-            "      // This is required to detect the moment when Ketch Tag is loaded successfully and ready\n" +
-            "      // TODO: Remove this once lanyard.js will emit \"onConfigLoaded\" event, to avoid redundant \"config.json\" requests to server\n" +
-            "      ketch('getFullConfig', function (config) {\n" +
-            "        emitEvent('onConfigLoaded', [config]);\n" +
-            "      });\n" +
-            "\n" +
-            "      // Simulating \"error\" event\n" +
-            "      // Capturing all the unhandled crashes of Ketch Tag\n" +
-            "      window.addEventListener('error', (event) => {\n" +
-            "        const errorMessage = '\${event.message}';\n" +
-            "        emitEvent('error', [errorMessage]);\n" +
-            "      });\n" +
-            "\n" +
-            "      // Capturing all the unhandled promise rejections of Ketch Tag\n" +
-            "      window.addEventListener('unhandledrejection', (event) => {\n" +
-            "        const errorMessage = '\${event.reason.message}';\n" +
-            "        emitEvent('error', [errorMessage]);\n" +
-            "      });\n" +
-            "\n" +
-            "      // Capturing all the internal logging for errors handled by Ketch Tag\n" +
-            "      // TODO: Remove this once lanyard.js will emit error events\n" +
-            "      ((logger) => {\n" +
-            "        var oldErr = logger.error;\n" +
-            "        logger.error = (...args) => {\n" +
-            "          emitEvent('error', [args.join(' ')]);\n" +
-            "          oldErr(...args);\n" +
-            "        };\n" +
-            "      })(window.console);\n" +
-            "\n" +
-            "      // A temporary workaround to get banner/modal dimensions on tablets\n" +
-            "      // TODO: remove this once there will be a way to get dialogs position from JS SDK\n" +
-            "      function getDialogSize() {\n" +
-            "        var domElem = document.querySelector(\n" +
-            "          '#lanyard_root div[role=\"dialog\"]'\n" +
-            "        );\n" +
-            "        if (!domElem) {\n" +
-            "          return;\n" +
-            "        }\n" +
-            "        var domRect = domElem.getBoundingClientRect();\n" +
-            "        if (domRect) {\n" +
-            "          return domRect;\n" +
-            "        }\n" +
-            "      }\n" +
-            "\n" +
-            "      function initKetchTag(parameters) {\n" +
-            "        console.log('Ketch Tag is initialization started...');\n" +
-            "        // Use parameters to set SDK query params here\n" +
-            "        const urlParams = new URLSearchParams(parameters);\n" +
-            "        window.history.replaceState({}, '', '?' + urlParams.toString());\n" +
-            "\n" +
-            "        console.log('Ketch Parameters BEFORE:', parameters);\n" +
-            "        // Get query parameters\n" +
-            "        let params = new URL(document.location).searchParams;\n" +
-            "\n" +
-            "        console.log('Ketch Parameters AFTER:', params);\n" +
-            "\n" +
-            "        var e = document.createElement('script');\n" +
-            "        e.type = 'text/javascript';\n" +
-            "        e.src = `${ketchMobileSdkUrl}/config/${orgCode}/${propertyName}/boot.js`;\n" +
-            "        e.defer = e.async = !0;\n" +
-            "        document.getElementsByTagName('head')[0].appendChild(e);\n" +
-            "      }\n" +
-            "      // We put the script inside body, otherwise document.body will be null\n" +
-            "      // Trigger taps outside the dialog\n" +
-            "      document.body.addEventListener('touchstart', function (e) {\n" +
-            "        if (e.target === document.body) {\n" +
-            "          emitEvent('tapOutside', [getDialogSize()]);\n" +
-            "        }\n" +
-            "      });\n" +
-            "      initKetchTag({" +
-            "ketch_log: \"${logLevel}\"," +
-            if (language?.isNotBlank() == true) {
-                "ketch_lang: \"${language}\","
-            } else {
-                ""
-            } +
-            if (jurisdiction?.isNotBlank() == true) {
-                "ketch_jurisdiction: \"${jurisdiction}\","
-            } else {
-                ""
-            } +
-            if (region?.isNotBlank() == true) {
-                "ketch_region: \"${region}\","
-            } else {
-                ""
-            } +
-            if (forceShow?.isNotBlank() == true) {
-                "ketch_show: \"${forceShow}\","
-            } else {
-                ""
-            } +
-            if (preferencesTabs?.isNotBlank() == true) {
-                "ketch_preferences_tabs: \"${preferencesTabs}\","
-            } else {
-                ""
-            } +
-            if (preferencesTab?.isNotBlank() == true) {
-                "ketch_preferences_tab: \"${preferencesTab}\","
-            } else {
-                ""
-            } +
-            if (environment?.isNotBlank() == true) {
-                "ketch_env: \"${environment}\","
-            } else {
-                ""
-            } +
-            if (age != null && age >= 0) {
-                "ketch_age: \"${age}\","
-            } else {
-                ""
-            } +
-            if (ageLower != null && ageLower >= 0) {
-                "ketch_age_lower: \"${ageLower}\","
-            } else {
-                ""
-            } +
-            if (ageUpper != null && ageUpper >= 0) {
-                "ketch_age_upper: \"${ageUpper}\","
-            } else {
-                ""
-            } +
-            identities +
-            "});" +
-            "    </script>\n" +
-            "  </body>\n" +
-            "</html>"
+    cssStyleOverride: String? = null,
+    webResourceUrlOverrides: Map<String, String> = emptyMap(),
+): String {
+    val paramsJson = buildInitParamsJson(
+        orgCode = orgCode,
+        propertyName = propertyName,
+        ketchMobileSdkUrl = ketchMobileSdkUrl,
+        logLevel = logLevel,
+        language = language,
+        jurisdiction = jurisdiction,
+        identities = identities,
+        region = region,
+        environment = environment,
+        forceShow = forceShow,
+        preferencesTabs = preferencesTabs,
+        preferencesTab = preferencesTab,
+        age = age,
+        ageLower = ageLower,
+        ageUpper = ageUpper,
+        webResourceUrlOverrides = webResourceUrlOverrides,
+    )
+
+    return """
+<html>
+  <head>
+    <style>
+      body {
+        height: 100dvh;
+        width: 100dvw;
+        min-height: -webkit-fill-available;
+        --safe-area-inset-bottom: $bottomPadding;
+        --safe-area-inset-top: $topPadding;
+      }
+      [role="dialog"], .ketch-experience, #ketch-root, [data-ketch-root] {
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        z-index: 2147483647 !important;
+      }
+    </style>
+    ${cssStyleOverride?.takeIf { it.isNotBlank() }?.let { "<style>$it</style>" } ?: ""}
+    <meta
+      name="viewport"
+      content="width=device-width, height=device-height, initial-scale=1, viewport-fit=cover"
+    />
+  </head>
+  <body>
+    <script>
+      (function () {
+        function emitEvent(event, args) {
+          if (
+            window.androidListener ||
+            (window.webkit && window.webkit.messageHandlers) ||
+            (window.ReactNativeWebView && window.ReactNativeWebView.postMessage)
+          ) {
+            const filteredArgs = [];
+            for (const arg of args) {
+              if (arg !== this) filteredArgs.push(arg);
+            }
+            let argument;
+            if (filteredArgs.length === 1 && typeof filteredArgs[0] === 'string') {
+              argument = filteredArgs[0];
+            } else if (filteredArgs.length === 1) {
+              argument = JSON.stringify(filteredArgs[0]);
+            } else if (filteredArgs.length > 1) {
+              argument = JSON.stringify(filteredArgs);
+            }
+            if (window.androidListener && event in window.androidListener) {
+              if (filteredArgs.length === 0) {
+                window.androidListener[event]();
+              } else {
+                window.androidListener[event](argument);
+              }
+            } else if (
+              window.webkit &&
+              window.webkit.messageHandlers &&
+              event in window.webkit.messageHandlers
+            ) {
+              window.webkit.messageHandlers[event].postMessage(argument);
+            } else if (window.ReactNativeWebView && window.ReactNativeWebView.postMessage) {
+              window.ReactNativeWebView.postMessage(JSON.stringify({ event, data: argument }));
+            }
+          }
+        }
+
+        window.addEventListener('error', function (event) {
+          emitEvent('error', [String(event.message || 'Unknown error')]);
+        });
+        window.addEventListener('unhandledrejection', function (event) {
+          var reason = event.reason && event.reason.message ? event.reason.message : 'Unhandled rejection';
+          emitEvent('error', [String(reason)]);
+        });
+
+        window.semaphore = window.semaphore || [];
+        window.ketch = function () {
+          window.semaphore.push(arguments);
+        };
+        window.__noop = function () {};
+
+        var params = $paramsJson;
+        window.__ketchParams = params;
+
+        ${webResourceUrlOverridesInstallScriptBody()}
+
+        function __ketchApplyUrlFromParams(p) {
+          try {
+            var urlParams = {
+              organizationCode: p.organizationCode,
+              propertyCode: p.propertyCode,
+              ketch_lang: p.languageCode || null,
+              ketch_log: p.logLevel || null,
+              ketch_mobilesdk_url: p.ketch_mobilesdk_url || null,
+              ketch_env: p.environmentName || null,
+              ketch_jurisdiction: p.jurisdictionCode || null,
+              ketch_region: p.regionCode || null,
+              ketch_show: p.ketch_show || null,
+              ketch_preferences_tabs: p.ketch_preferences_tabs || null,
+              ketch_preferences_tab: p.ketch_preferences_tab || null,
+              ketch_age: p.age != null && p.age >= 0 ? String(p.age) : null,
+              ketch_age_lower: p.ageLower != null && p.ageLower >= 0 ? String(p.ageLower) : null,
+              ketch_age_upper: p.ageUpper != null && p.ageUpper >= 0 ? String(p.ageUpper) : null,
+            };
+            if (p.identities && typeof p.identities === 'object') {
+              Object.keys(p.identities).forEach(function (k) {
+                urlParams[k] = p.identities[k];
+              });
+            }
+            Object.keys(urlParams).forEach(function (k) {
+              if (urlParams[k] == null || urlParams[k] === '') delete urlParams[k];
+            });
+            var qs = new URLSearchParams(urlParams).toString();
+            history.replaceState({}, '', (location.pathname || '/') + (qs ? ('?' + qs) : '') + (location.hash || ''));
+          } catch (e) {
+            console.error('applyUrl error', e);
+          }
+        }
+
+        var WEB_BASE = params.ketch_mobilesdk_url || 'https://global.ketchcdn.com/web/v3';
+
+        function loadScript(src) {
+          return new Promise(function (resolve, reject) {
+            try {
+              var s = document.createElement('script');
+              s.src = src;
+              s.async = true;
+              s.defer = true;
+              s.onload = resolve;
+              s.onerror = reject;
+              document.head.appendChild(s);
+            } catch (e) {
+              reject(e);
+            }
+          });
+        }
+
+        function loadBoot() {
+          return loadScript(
+            WEB_BASE + '/config/' + params.organizationCode + '/' + params.propertyCode + '/boot.js'
+          );
+        }
+
+        function bindEventListeners() {
+          try {
+            window.ketch('on', 'willShowExperience', function (p) {
+              emitEvent('willShowExperience', [p]);
+            });
+            window.ketch('on', 'hasShownExperience', function () {
+              emitEvent('hasShownExperience', ['1']);
+            });
+            window.ketch('on', 'hideExperience', function (p) {
+              emitEvent('hideExperience', [p]);
+            });
+            window.ketch('on', 'environment', function (e) {
+              emitEvent('environment', [e]);
+            });
+            window.ketch('on', 'regionInfo', function (r) {
+              emitEvent('regionInfo', [r]);
+            });
+            window.ketch('on', 'jurisdiction', function (j) {
+              emitEvent('jurisdiction', [j]);
+            });
+            window.ketch('on', 'identities', function (i) {
+              emitEvent('identities', [i]);
+            });
+            window.ketch('on', 'consent', function (c) {
+              emitEvent('consent', [c]);
+            });
+            window.ketch('on', 'usprivacy_updated_data', function (k, a) {
+              emitEvent('usprivacy_updated_data', [k, a]);
+            });
+            window.ketch('on', 'gpp_updated_data', function (k, a) {
+              emitEvent('gpp_updated_data', [k, a]);
+            });
+            window.ketch('on', 'tcf_updated_data', function (k, a) {
+              emitEvent('tcf_updated_data', [k, a]);
+            });
+          } catch (e) {
+            console.error('bindEventListeners failed', e);
+          }
+        }
+
+        function maybeAutoShow() {
+          try {
+            var showConsent =
+              params.forceConsentExperience ||
+              params.ketch_show === 'consent' ||
+              params.ketch_show === 'cd';
+            if (showConsent) {
+              try { window.ketch('showConsent'); } catch (_) {
+                try { window.ketch('showExperience', 'consent', window.__noop); } catch (_) {
+                  try { window.ketch('renderExperience', 'consent', window.__noop); } catch (_) {}
+                }
+              }
+            }
+            var showPreferences =
+              params.forcePreferenceExperience || params.ketch_show === 'preferences';
+            if (showPreferences) {
+              try { window.ketch('showPreferences'); } catch (_) {
+                try { window.ketch('showExperience', 'preferences', window.__noop); } catch (_) {
+                  try { window.ketch('renderExperience', 'preferences', window.__noop); } catch (_) {}
+                }
+              }
+            }
+          } catch (e) {
+            console.error('autoShow error', e);
+          }
+        }
+
+        window.ketch('getFullConfig', function (cfg) {
+          emitEvent('onConfigLoaded', [cfg]);
+          bindEventListeners();
+          maybeAutoShow();
+        });
+
+        if (params.webResourceUrlOverrides) {
+          installWebResourceUrlOverrides(params.webResourceUrlOverrides);
+        }
+
+        __ketchApplyUrlFromParams(params);
+        loadBoot().catch(function (e) {
+          console.error('asset load error (boot)', e && e.message ? e.message : e);
+        });
+
+        function getDialogSize() {
+          var domElem = document.querySelector('#lanyard_root div[role="dialog"]');
+          if (!domElem) return;
+          return domElem.getBoundingClientRect();
+        }
+
+        function triggerOutsideTapDismiss() {
+          var selectors = [
+            '#lanyard_root button[aria-label="close banner"]',
+            '#lanyard_root button[aria-label="close modal"]',
+          ];
+          for (var i = 0; i < selectors.length; i++) {
+            var btn = document.querySelector(selectors[i]);
+            if (btn) {
+              btn.click();
+              return true;
+            }
+          }
+          return false;
+        }
+
+        document.body.addEventListener('touchstart', function (e) {
+          if (e.target === document.body) {
+            if (!triggerOutsideTapDismiss()) {
+              emitEvent('tapOutside', [getDialogSize()]);
+            }
+          }
+        });
+      })();
+    </script>
+  </body>
+</html>
+""".trimIndent()
+}
+
+private fun buildInitParamsJson(
+    orgCode: String,
+    propertyName: String,
+    ketchMobileSdkUrl: String,
+    logLevel: String,
+    language: String?,
+    jurisdiction: String?,
+    identities: Map<String, String>,
+    region: String?,
+    environment: String?,
+    forceShow: String?,
+    preferencesTabs: String?,
+    preferencesTab: String?,
+    age: Int?,
+    ageLower: Int?,
+    ageUpper: Int?,
+    webResourceUrlOverrides: Map<String, String>,
+): String {
+    val params = linkedMapOf<String, Any>(
+        "organizationCode" to orgCode,
+        "propertyCode" to propertyName,
+        "ketch_mobilesdk_url" to ketchMobileSdkUrl,
+        "logLevel" to logLevel,
+    )
+    language?.takeIf { it.isNotBlank() }?.let { params["languageCode"] = it }
+    jurisdiction?.takeIf { it.isNotBlank() }?.let { params["jurisdictionCode"] = it }
+    region?.takeIf { it.isNotBlank() }?.let { params["regionCode"] = it }
+    environment?.takeIf { it.isNotBlank() }?.let { params["environmentName"] = it }
+    preferencesTabs?.takeIf { it.isNotBlank() }?.let { params["ketch_preferences_tabs"] = it }
+    preferencesTab?.takeIf { it.isNotBlank() }?.let { params["ketch_preferences_tab"] = it }
+    if (age != null && age >= 0) params["age"] = age
+    if (ageLower != null && ageLower >= 0) params["ageLower"] = ageLower
+    if (ageUpper != null && ageUpper >= 0) params["ageUpper"] = ageUpper
+    if (identities.isNotEmpty()) params["identities"] = identities
+    if (webResourceUrlOverrides.isNotEmpty()) params["webResourceUrlOverrides"] = webResourceUrlOverrides
+
+    when (forceShow?.lowercase()) {
+        "consent", "cd" -> {
+            params["forceConsentExperience"] = true
+            params["ketch_show"] = "consent"
+        }
+        "preferences" -> {
+            params["forcePreferenceExperience"] = true
+            params["ketch_show"] = "preferences"
+        }
+        null, "" -> Unit
+        else -> params["ketch_show"] = forceShow
+    }
+
+    return Gson().toJson(params)
+}
+
+private fun webResourceUrlOverridesInstallScriptBody(): String =
+    """
+        function installWebResourceUrlOverrides(overrides) {
+          if (!overrides || !Object.keys(overrides).length) return;
+          function resolveUrl(url) {
+            if (!url) return url;
+            if (overrides[url]) return overrides[url];
+            var base = url.split('?')[0].split('#')[0];
+            if (base !== url && overrides[base]) return overrides[base];
+            for (var key in overrides) {
+              if (!Object.prototype.hasOwnProperty.call(overrides, key)) continue;
+              if (key === url || key === base) continue;
+              if (key.charAt(0) === '/' && base.indexOf(key) !== -1) return overrides[key];
+              if (key.indexOf('://') !== -1) continue;
+              if (base.endsWith(key) || base.indexOf('/' + key) !== -1) return overrides[key];
+            }
+            return url;
+          }
+          var srcDesc = Object.getOwnPropertyDescriptor(HTMLScriptElement.prototype, 'src');
+          if (srcDesc && srcDesc.set) {
+            var nativeSrcSet = srcDesc.set;
+            var nativeSrcGet = srcDesc.get;
+            Object.defineProperty(HTMLScriptElement.prototype, 'src', {
+              set: function (value) { nativeSrcSet.call(this, resolveUrl(value)); },
+              get: nativeSrcGet,
+              configurable: true,
+            });
+          }
+          var origSetAttribute = Element.prototype.setAttribute;
+          Element.prototype.setAttribute = function (name, value) {
+            if (name === 'src' && this.tagName === 'SCRIPT') {
+              return origSetAttribute.call(this, name, resolveUrl(value));
+            }
+            return origSetAttribute.call(this, name, value);
+          };
+          if (window.fetch) {
+            var origFetch = window.fetch.bind(window);
+            window.fetch = function (input, init) {
+              if (typeof input === 'string') {
+                var mapped = resolveUrl(input);
+                if (mapped !== input) input = mapped;
+              } else if (input && input.url) {
+                var mappedUrl = resolveUrl(input.url);
+                if (mappedUrl !== input.url) input = new Request(mappedUrl, input);
+              }
+              return origFetch(input, init);
+            };
+          }
+        }
+    """.trimIndent()

--- a/ketchsdk/src/main/java/com/ketch/android/ui/KetchWebView.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/ui/KetchWebView.kt
@@ -22,6 +22,10 @@ import com.google.gson.FieldNamingPolicy
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonParseException
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
 import com.ketch.android.Ketch
 import com.ketch.android.NativeStorage
 import com.ketch.android.NativeStoragePutPayload
@@ -30,8 +34,6 @@ import com.ketch.android.data.ContentDisplay
 import com.ketch.android.data.HideExperienceStatus
 import com.ketch.android.data.KetchConfig
 import com.ketch.android.data.WillShowExperienceType
-import com.ketch.android.data.summarizeConfigJson
-import com.ketch.android.data.summarizePurposesJson
 import com.ketch.android.data.getIndexHtml
 import com.ketch.android.data.parseHideExperienceStatus
 import com.ketch.android.data.parseWillShowExperienceType
@@ -593,4 +595,82 @@ class KetchWebView(context: Context, shouldRetry: Boolean = false) : WebView(con
         private const val TRIGGER_OUTSIDE_TAP_DISMISS_JS =
             "(function(){if(typeof triggerOutsideTapDismiss==='function'){return triggerOutsideTapDismiss();}return false;})()"
     }
+}
+
+private fun summarizeConfigJson(configJson: String?): String {
+    if (configJson.isNullOrBlank()) return "config: empty"
+    return try {
+        val root = JsonParser.parseString(configJson)
+        if (!root.isJsonObject) return "config: not an object"
+        summarizeConfigElement(root.asJsonObject)
+    } catch (e: Exception) {
+        "config parse error: ${e.message}"
+    }
+}
+
+private fun summarizePurposesJson(configJson: String?): String {
+    if (configJson.isNullOrBlank()) return "purposes: empty"
+    return try {
+        val root = JsonParser.parseString(configJson)
+        if (!root.isJsonObject) return "purposes: n/a"
+        summarizePurposesElement(root.asJsonObject)
+    } catch (e: Exception) {
+        "purposes parse error: ${e.message}"
+    }
+}
+
+private fun summarizeConfigElement(root: JsonObject): String {
+    val env = root.get("environment")?.asJsonObject?.get("code")?.asString
+    val jurisdiction = root.get("jurisdiction")?.asJsonObject?.get("code")?.asString
+        ?: root.get("policyScope")?.asJsonObject?.get("code")?.asString
+    val language = root.get("language")?.asString
+    val experiences = summarizeExperiences(root.get("experiences"))
+    return buildString {
+        append("env=").append(env ?: "?")
+        append(" jurisdiction=").append(jurisdiction ?: "?")
+        append(" lang=").append(language ?: "?")
+        append(" ").append(experiences)
+    }
+}
+
+private fun summarizePurposesElement(root: JsonObject): String {
+    val canonical = root.getAsJsonObject("canonicalPurposes")
+    if (canonical != null && canonical.size() > 0) {
+        val codes = canonical.entrySet().map { it.key }.sorted()
+        return "canonicalPurposes(${codes.size}): ${codes.joinToString(", ")}"
+    }
+    val purposes = root.getAsJsonArray("purposes")
+    if (purposes != null && purposes.size() > 0) {
+        val codes = purposes.mapNotNull { element ->
+            element.asJsonObject.get("code")?.asString
+        }.sorted()
+        return "purposes(${codes.size}): ${codes.joinToString(", ")}"
+    }
+    return "purposes: none in config.json"
+}
+
+private fun summarizeExperiences(experiences: JsonElement?): String {
+    if (experiences == null || experiences.isJsonNull) return "experiences=none"
+    if (!experiences.isJsonObject) return "experiences=unexpected"
+    val obj = experiences.asJsonObject
+    val keys = obj.keySet().sorted()
+    val autoInitiated = obj.getAsJsonObject("autoInitiated")
+    val layout = autoInitiated?.getAsJsonObject("layout")
+    val banner = layout?.has("banner") == true
+    val modal = layout?.has("modal") == true
+    val pref = layout?.has("preference") == true
+    return buildString {
+        append("experiences keys=[${keys.joinToString(",")}]")
+        if (layout != null) {
+            append(" layout banner=$banner modal=$modal pref=$pref")
+        }
+    }
+}
+
+private fun JsonArray.mapNotNull(transform: (JsonElement) -> String?): List<String> {
+    val result = mutableListOf<String>()
+    for (element in this) {
+        transform(element)?.let { result.add(it) }
+    }
+    return result
 }

--- a/ketchsdk/src/main/java/com/ketch/android/ui/WebResourceOverrideHandler.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/ui/WebResourceOverrideHandler.kt
@@ -1,0 +1,68 @@
+package com.ketch.android.ui
+
+import android.util.Log
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * Redirects exact-match WebView resource URLs (e.g. UAT tag scripts) to local dev servers.
+ */
+internal object WebResourceOverrideHandler {
+    private const val TAG = "KetchWebOverride"
+
+    fun intercept(
+        overrides: Map<String, String>,
+        request: WebResourceRequest?,
+    ): WebResourceResponse? {
+        if (overrides.isEmpty() || request == null) return null
+        val sourceUrl = request.url?.toString() ?: return null
+        val destinationUrl = resolveOverrideUrl(sourceUrl, overrides) ?: return null
+        return loadResponse(sourceUrl, destinationUrl)
+    }
+
+    private fun resolveOverrideUrl(sourceUrl: String, overrides: Map<String, String>): String? {
+        if (overrides.isEmpty() || sourceUrl.isBlank()) return null
+
+        overrides[sourceUrl]?.let { return it }
+
+        val base = sourceUrl.substringBefore('#').substringBefore('?')
+        if (base != sourceUrl) {
+            overrides[base]?.let { return it }
+        }
+
+        for ((pattern, destination) in overrides) {
+            if (pattern == sourceUrl || pattern == base) continue
+            when {
+                pattern.startsWith("/") && base.contains(pattern) -> return destination
+                pattern.contains("://") -> Unit
+                base.endsWith(pattern) || base.contains("/$pattern") -> return destination
+            }
+        }
+        return null
+    }
+
+    private fun loadResponse(sourceUrl: String, destinationUrl: String): WebResourceResponse? {
+        return try {
+            val connection = URL(destinationUrl).openConnection() as HttpURLConnection
+            connection.connect()
+            Log.d(TAG, "Redirected $sourceUrl -> $destinationUrl")
+            WebResourceResponse(
+                mimeTypeFor(destinationUrl),
+                connection.contentEncoding ?: "UTF-8",
+                connection.inputStream,
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed override $sourceUrl -> $destinationUrl: ${e.message}", e)
+            null
+        }
+    }
+
+    private fun mimeTypeFor(url: String): String = when {
+        url.endsWith(".js", ignoreCase = true) -> "application/javascript"
+        url.endsWith(".json", ignoreCase = true) -> "application/json"
+        url.endsWith(".css", ignoreCase = true) -> "text/css"
+        else -> "text/plain"
+    }
+}

--- a/ketchsdk/src/test/java/com/ketch/android/api/HeadlessApiClientTest.kt
+++ b/ketchsdk/src/test/java/com/ketch/android/api/HeadlessApiClientTest.kt
@@ -1,0 +1,84 @@
+package com.ketch.android.api
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HeadlessApiClientTest {
+    private val client = HeadlessApiClient(KetchDataCenter.US)
+
+    @Test
+    fun buildUrl_ip() {
+        assertEquals(
+            "https://global.ketchcdn.com/web/v3/ip",
+            client.buildUrl("/ip"),
+        )
+    }
+
+    @Test
+    fun buildUrl_bootstrap() {
+        assertEquals(
+            "https://global.ketchcdn.com/web/v3/config/acme/prop/boot.json",
+            client.buildUrl("/config/acme/prop/boot.json"),
+        )
+    }
+
+    @Test
+    fun buildUrl_fullConfigurationWithHash() {
+        assertEquals(
+            "https://global.ketchcdn.com/web/v3/config/acme/prop/prod/us-ca/en-US/config.json?hash=8913461971881236311",
+            client.buildUrl(
+                "/config/acme/prop/prod/us-ca/en-US/config.json",
+                mapOf("hash" to "8913461971881236311"),
+            ),
+        )
+    }
+
+    @Test
+    fun buildUrl_euDataCenter() {
+        val eu = HeadlessApiClient(KetchDataCenter.EU)
+        assertEquals("https://eu.ketchcdn.com/web/v3/ip", eu.buildUrl("/ip"))
+    }
+
+    @Test
+    fun preferenceQRUrl_matchesContractFixture() {
+        val url = client.preferenceQRUrl(
+            com.ketch.android.data.PreferenceQRRequest(
+                organizationCode = "switchbitcorp",
+                propertyCode = "switchbit",
+                environmentCode = "production",
+                imageSize = 1024,
+                path = "/policy.html",
+                backgroundColor = "white",
+                foregroundColor = "black",
+                parameters = mapOf("foo" to "bar"),
+            ),
+        )
+        assertEquals(
+            "https://global.ketchcdn.com/web/v3/qr/switchbitcorp/switchbit/preferences.png?env=production&size=1024&path=%2Fpolicy.html&bgcolor=white&fgcolor=black&foo=bar",
+            url,
+        )
+    }
+
+    @Test
+    fun buildUrl_rightsProfileSubscriptions() {
+        assertEquals(
+            "https://global.ketchcdn.com/web/v3/rights/switchbitcorp/invoke",
+            client.buildUrl("/rights/switchbitcorp/invoke"),
+        )
+        assertEquals(
+            "https://global.ketchcdn.com/web/v3/profile/acme/get",
+            client.buildUrl("/profile/acme/get"),
+        )
+        assertEquals(
+            "https://global.ketchcdn.com/web/v3/subscriptions/acme/update",
+            client.buildUrl("/subscriptions/acme/update"),
+        )
+    }
+
+    @Test
+    fun ketchDataCenterBaseUrls() {
+        assertEquals("https://global.ketchcdn.com/web/v3", KetchDataCenter.US.baseUrl)
+        assertEquals("https://eu.ketchcdn.com/web/v3", KetchDataCenter.EU.baseUrl)
+        assertEquals("https://dev.ketchcdn.com/web/v3", KetchDataCenter.UAT.baseUrl)
+    }
+}

--- a/ketchsdk/src/test/java/com/ketch/android/api/HeadlessConsentPayloadTest.kt
+++ b/ketchsdk/src/test/java/com/ketch/android/api/HeadlessConsentPayloadTest.kt
@@ -1,0 +1,94 @@
+package com.ketch.android.api
+
+import com.google.gson.Gson
+import com.ketch.android.data.ConsentConfig
+import com.ketch.android.data.ConsentUpdate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HeadlessConsentPayloadTest {
+    private val gson = Gson()
+
+    @Test
+    fun setConsentPayloadOmitsProtocols() {
+        val update = ConsentUpdate(
+            organizationCode = "org",
+            propertyCode = "prop",
+            environmentCode = "production",
+            identities = mapOf("id" to "1"),
+            jurisdictionCode = "default",
+            migrationOption = ConsentUpdate.MigrationOption.MIGRATE_DEFAULT,
+            purposes = mapOf(
+                "analytics" to ConsentUpdate.PurposeAllowedLegalBasis(
+                    allowed = true,
+                    legalBasisCode = "consent_optin",
+                ),
+            ),
+            vendors = null,
+            protocols = mapOf("gpp" to "DBABLA~"),
+        )
+        val payload = SetConsentPayloadForTesting.from(update.copy(protocols = null))
+        val json = gson.toJsonTree(payload).asJsonObject
+        assertNull(json.get("protocols"))
+        assertEquals("org", json.get("organizationCode").asString)
+    }
+
+    @Test
+    fun consentConfigPayloadOmitsCachedAt() {
+        val config = ConsentConfig(
+            organizationCode = "org",
+            propertyCode = "prop",
+            environmentCode = "production",
+            jurisdictionCode = "default",
+            identities = emptyMap(),
+            purposes = emptyMap(),
+        )
+        val json = gson.toJsonTree(ConsentConfigPayloadForTesting.from(config)).asJsonObject
+        assertNull(json.get("cachedAt"))
+    }
+
+    private data class SetConsentPayloadForTesting(
+        val organizationCode: String,
+        val propertyCode: String,
+        val environmentCode: String,
+        val identities: Map<String, String>,
+        val jurisdictionCode: String,
+        val migrationOption: ConsentUpdate.MigrationOption,
+        val purposes: Map<String, ConsentUpdate.PurposeAllowedLegalBasis>,
+        val vendors: List<String>?,
+    ) {
+        companion object {
+            fun from(update: ConsentUpdate) = SetConsentPayloadForTesting(
+                organizationCode = update.organizationCode,
+                propertyCode = update.propertyCode,
+                environmentCode = update.environmentCode,
+                identities = update.identities,
+                jurisdictionCode = update.jurisdictionCode,
+                migrationOption = update.migrationOption,
+                purposes = update.purposes,
+                vendors = update.vendors,
+            )
+        }
+    }
+
+    private data class ConsentConfigPayloadForTesting(
+        val organizationCode: String,
+        val propertyCode: String,
+        val environmentCode: String,
+        val jurisdictionCode: String,
+        val identities: Map<String, String>,
+        val purposes: Map<String, ConsentConfig.PurposeLegalBasis>,
+    ) {
+        companion object {
+            fun from(config: ConsentConfig) = ConsentConfigPayloadForTesting(
+                organizationCode = config.organizationCode,
+                propertyCode = config.propertyCode,
+                environmentCode = config.environmentCode,
+                jurisdictionCode = config.jurisdictionCode,
+                identities = config.identities,
+                purposes = config.purposes,
+            )
+        }
+    }
+}

--- a/ketchsdk/src/test/java/com/ketch/android/api/HeadlessConsentTest.kt
+++ b/ketchsdk/src/test/java/com/ketch/android/api/HeadlessConsentTest.kt
@@ -1,0 +1,168 @@
+package com.ketch.android.api
+
+import com.ketch.android.data.Consent
+import com.ketch.android.data.ConsentConfig
+import com.ketch.android.data.ConsentUpdate
+import com.ketch.android.data.HeadlessException
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+import java.net.HttpURLConnection
+
+class HeadlessConsentTest {
+    private lateinit var mockWebServer: MockWebServer
+
+    @Before
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun fetchConsentPropagatesHttpFailure() = runBlocking {
+        mockWebServer.enqueue(MockResponse().setResponseCode(HttpURLConnection.HTTP_INTERNAL_ERROR))
+
+        val client = headlessClient()
+        try {
+            client.fetchConsent(sampleConsentConfig())
+            fail("Expected fetchConsent to fail on HTTP 500")
+        } catch (error: HeadlessException) {
+            assertTrue(error.message?.contains("HTTP 500") == true)
+        }
+    }
+
+    @Test
+    fun setConsentPropagatesNetworkFailure() = runBlocking {
+        val failingClient = OkHttpClient.Builder()
+            .addInterceptor { throw IOException("not connected to internet") }
+            .build()
+        val client = HeadlessApiClient(
+            dataCenter = KetchDataCenter.US,
+            okHttpClient = failingClient,
+        )
+
+        try {
+            client.setConsent(sampleConsentUpdate())
+            fail("Expected setConsent to fail on network error")
+        } catch (error: HeadlessException) {
+            assertTrue(error.message?.contains("Network error") == true)
+            assertTrue(error.cause != null)
+        }
+    }
+
+    @Test
+    fun fetchConsentReturnsEmptyConsentOn200NullBody() = runBlocking {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(HttpURLConnection.HTTP_OK)
+                .setBody("null")
+                .addHeader("Content-Type", "application/json"),
+        )
+
+        val client = headlessClient()
+        val consent = client.fetchConsent(sampleConsentConfig())
+
+        assertEquals(emptyMap<String, Boolean>(), consent.purposes)
+        assertNull(consent.vendors)
+        assertNull(consent.protocols)
+    }
+
+    @Test
+    fun fetchProtocolsPreservesPurposesWhenProtocolsMissing() = runBlocking {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(HttpURLConnection.HTTP_OK)
+                .setBody("""{"purposes":{"analytics":true,"marketing":false}}""")
+                .addHeader("Content-Type", "application/json"),
+        )
+
+        val client = headlessClient()
+        val consent = client.fetchProtocols(sampleConsentConfig())
+
+        assertNull(consent.protocols)
+        assertEquals(true, consent.purposes?.get("analytics"))
+        assertEquals(false, consent.purposes?.get("marketing"))
+    }
+
+    @Test
+    fun setConsentAcceptsProtocolsOnlyResponse() = runBlocking {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(HttpURLConnection.HTTP_OK)
+                .setBody("""{"protocols":{"gpp":"DBABLA~BVQqAAAAAAJY.QA"}}""")
+                .addHeader("Content-Type", "application/json"),
+        )
+
+        val client = headlessClient()
+        val consent = client.setConsent(sampleConsentUpdate())
+
+        assertNull(consent.purposes)
+        assertEquals("DBABLA~BVQqAAAAAAJY.QA", consent.protocols?.get("gpp"))
+    }
+
+    private fun headlessClient(): HeadlessApiClient {
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val original = chain.request()
+                val redirected = original.newBuilder()
+                    .url(
+                        original.url.newBuilder()
+                            .scheme("http")
+                            .host(mockWebServer.hostName)
+                            .port(mockWebServer.port)
+                            .build(),
+                    )
+                    .build()
+                chain.proceed(redirected)
+            }
+            .build()
+        return HeadlessApiClient(
+            dataCenter = KetchDataCenter.US,
+            okHttpClient = okHttpClient,
+        )
+    }
+
+    private fun sampleConsentConfig(): ConsentConfig =
+        ConsentConfig(
+            organizationCode = "org",
+            propertyCode = "prop",
+            environmentCode = "production",
+            jurisdictionCode = "default",
+            identities = mapOf("email" to "user@example.com"),
+            purposes = mapOf(
+                "analytics" to ConsentConfig.PurposeLegalBasis(legalBasisCode = "consent_optin"),
+            ),
+        )
+
+    private fun sampleConsentUpdate(): ConsentUpdate =
+        ConsentUpdate(
+            organizationCode = "org",
+            propertyCode = "prop",
+            environmentCode = "production",
+            identities = mapOf("email" to "user@example.com"),
+            jurisdictionCode = "default",
+            migrationOption = ConsentUpdate.MigrationOption.MIGRATE_DEFAULT,
+            purposes = mapOf(
+                "analytics" to ConsentUpdate.PurposeAllowedLegalBasis(
+                    allowed = true,
+                    legalBasisCode = "consent_optin",
+                ),
+            ),
+            vendors = null,
+            protocols = null,
+        )
+}

--- a/ketchsdk/src/test/java/com/ketch/android/data/EventsTest.kt
+++ b/ketchsdk/src/test/java/com/ketch/android/data/EventsTest.kt
@@ -1,0 +1,27 @@
+package com.ketch.android.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EventsTest {
+
+    @Test
+    fun parseHideExperienceStatus_mapsKnownReasons() {
+        assertEquals(HideExperienceStatus.SetConsent, parseHideExperienceStatus("setConsent"))
+        assertEquals(HideExperienceStatus.InvokeRight, parseHideExperienceStatus("invokeRight"))
+        assertEquals(HideExperienceStatus.Close, parseHideExperienceStatus("close"))
+        assertEquals(
+            HideExperienceStatus.CloseWithoutSettingConsent,
+            parseHideExperienceStatus("closeWithoutSettingConsent")
+        )
+        assertEquals(HideExperienceStatus.WillNotShow, parseHideExperienceStatus("willNotShow"))
+        assertEquals(HideExperienceStatus.SetSubscriptions, parseHideExperienceStatus("setSubscriptions"))
+    }
+
+    @Test
+    fun parseHideExperienceStatus_unknownReasonFallsBackToNone() {
+        assertEquals(HideExperienceStatus.None, parseHideExperienceStatus("unknownReason"))
+        assertEquals(HideExperienceStatus.None, parseHideExperienceStatus(null))
+        assertEquals(HideExperienceStatus.None, parseHideExperienceStatus(""))
+    }
+}

--- a/sample-app-compose/src/main/java/com/ketch/android/sample/compose/KetchSampleApp.kt
+++ b/sample-app-compose/src/main/java/com/ketch/android/sample/compose/KetchSampleApp.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -28,6 +30,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
@@ -57,9 +60,17 @@ import com.ketch.android.sample.compose.ui.theme.LightToggleTrack
 
 @Composable
 fun KetchSampleApp(
-    logEntries: List<String>,
+    dashboard: SampleDashboardState,
+    connectionSummary: String,
+    onLoad: () -> Unit,
     onShowConsent: () -> Unit,
     onShowPreferences: () -> Unit,
+    onSetLanguage: () -> Unit,
+    onSetJurisdiction: () -> Unit,
+    onSetRegion: () -> Unit,
+    onHeadlessLocation: () -> Unit,
+    onHeadlessBootstrap: () -> Unit,
+    onHeadlessConsent: () -> Unit,
 ) {
     var isDarkMode by rememberSaveable { mutableStateOf(false) }
 
@@ -70,49 +81,102 @@ fun KetchSampleApp(
                 .background(MaterialTheme.colorScheme.background)
                 .windowInsetsPadding(WindowInsets.systemBars)
         ) {
-            HeaderBar(
-                isDarkMode = isDarkMode,
-                onToggleDarkMode = { isDarkMode = it }
-            )
-
-            HorizontalDivider(
-                color = if (isDarkMode) DarkDivider else LightDivider,
-                thickness = 1.dp
-            )
-
+            HeaderBar(isDarkMode = isDarkMode, onToggleDarkMode = { isDarkMode = it })
+            HorizontalDivider(color = if (isDarkMode) DarkDivider else LightDivider, thickness = 1.dp)
             Column(
                 modifier = Modifier
                     .weight(1f)
                     .verticalScroll(rememberScrollState())
                     .padding(20.dp)
             ) {
-                SectionHeader("Experience Functions")
-                Spacer(Modifier.height(16.dp))
-                CardsRow(
-                    onShowConsent = onShowConsent,
-                    onShowPreferences = onShowPreferences
-                )
-                Spacer(Modifier.height(24.dp))
-                SectionHeader("Event Log")
+                SectionHeader("SDK Health Dashboard")
+                DashboardRow("Init", dashboard.initState)
+                DashboardRow("Status", dashboard.statusText)
+                DashboardRow("Connection", connectionSummary)
+                DashboardRow("Load", dashboard.loadState)
+                DashboardRow("Visibility", dashboard.experienceVisibility)
+                DashboardRow("Dismiss", dashboard.dismissReason)
+
                 Spacer(Modifier.height(12.dp))
-                EventLog(
-                    entries = logEntries,
-                    isDarkMode = isDarkMode
-                )
+                SectionHeader("Privacy / Consent State")
+                DashboardRow("Environment", dashboard.environment)
+                DashboardRow("Jurisdiction", dashboard.jurisdiction)
+                DashboardRow("Region", dashboard.region)
+                DashboardRow("Consent", dashboard.consent)
+                DashboardRow("US Privacy", dashboard.usPrivacy)
+                DashboardRow("TCF", dashboard.tcf)
+                DashboardRow("GPP", dashboard.gpp)
+                DashboardRow("Config", dashboard.configSummary)
+                DashboardRow("Purposes", dashboard.purposesSummary)
+
+                Spacer(Modifier.height(12.dp))
+                SectionHeader("Actions")
+                ActionButtonsRow(onLoad, onShowConsent, onShowPreferences)
+                ConfigButtonsRow(onSetLanguage, onSetJurisdiction, onSetRegion)
+
+                Spacer(Modifier.height(12.dp))
+                SectionHeader("Headless (live CDN)")
+                DashboardRow("Location", dashboard.headlessLocationResult)
+                DashboardRow("Bootstrap", dashboard.headlessBootstrapResult)
+                DashboardRow("Consent", dashboard.headlessConsentResult)
+                HeadlessButtonsRow(onHeadlessLocation, onHeadlessBootstrap, onHeadlessConsent)
+
+                Spacer(Modifier.height(16.dp))
+                SectionHeader("Experience Functions")
+                Spacer(Modifier.height(12.dp))
+                CardsRow(onShowConsent = onShowConsent, onShowPreferences = onShowPreferences)
+
+                Spacer(Modifier.height(16.dp))
+                SectionHeader("Event Log")
+                Spacer(Modifier.height(8.dp))
+                EventLog(entries = dashboard.eventLog, isDarkMode = isDarkMode)
             }
         }
     }
 }
 
 @Composable
-private fun HeaderBar(
-    isDarkMode: Boolean,
-    onToggleDarkMode: (Boolean) -> Unit,
-) {
+private fun DashboardRow(label: String, value: String) {
+    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
+        Text("$label:", fontSize = 12.sp, modifier = Modifier.width(100.dp))
+        Text(value, fontSize = 12.sp, fontFamily = FontFamily.Monospace, modifier = Modifier.weight(1f))
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ActionButtonsRow(onLoad: () -> Unit, onShowConsent: () -> Unit, onShowPreferences: () -> Unit) {
+    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        OutlinedButton(onClick = onLoad) { Text("Load") }
+        OutlinedButton(onClick = onShowConsent) { Text("Show Consent") }
+        OutlinedButton(onClick = onShowPreferences) { Text("Show Preferences") }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ConfigButtonsRow(onLanguage: () -> Unit, onJurisdiction: () -> Unit, onRegion: () -> Unit) {
+    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        OutlinedButton(onClick = onLanguage) { Text("Set Language EN") }
+        OutlinedButton(onClick = onJurisdiction) { Text("Set Jurisdiction US") }
+        OutlinedButton(onClick = onRegion) { Text("Set Region CA") }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun HeadlessButtonsRow(onLocation: () -> Unit, onBootstrap: () -> Unit, onConsent: () -> Unit) {
+    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        OutlinedButton(onClick = onLocation) { Text("Fetch Location") }
+        OutlinedButton(onClick = onBootstrap) { Text("Fetch Bootstrap") }
+        OutlinedButton(onClick = onConsent) { Text("Cold Start") }
+    }
+}
+
+@Composable
+private fun HeaderBar(isDarkMode: Boolean, onToggleDarkMode: (Boolean) -> Unit) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 20.dp, vertical = 12.dp),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
@@ -120,10 +184,8 @@ private fun HeaderBar(
             fontSize = 20.sp,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onBackground,
-            modifier = Modifier.weight(1f)
+            modifier = Modifier.weight(1f),
         )
-        Text("☀️", fontSize = 16.sp)
-        Spacer(Modifier.width(4.dp))
         Switch(
             checked = isDarkMode,
             onCheckedChange = onToggleDarkMode,
@@ -132,134 +194,71 @@ private fun HeaderBar(
                 uncheckedTrackColor = if (isDarkMode) DarkToggleTrack else LightToggleTrack,
                 checkedThumbColor = KetchPurple,
                 uncheckedThumbColor = KetchPurple,
-            )
+            ),
         )
-        Spacer(Modifier.width(4.dp))
-        Text("🌙", fontSize = 16.sp)
     }
 }
 
 @Composable
 private fun SectionHeader(title: String) {
-    Text(
-        text = "▾  $title",
-        fontSize = 18.sp,
-        fontWeight = FontWeight.Bold,
-        color = KetchPurple,
-    )
+    Text(text = title, fontSize = 18.sp, fontWeight = FontWeight.Bold, color = KetchPurple)
 }
 
 @Composable
-private fun CardsRow(
-    onShowConsent: () -> Unit,
-    onShowPreferences: () -> Unit,
-) {
+private fun CardsRow(onShowConsent: () -> Unit, onShowPreferences: () -> Unit) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(IntrinsicSize.Max),
+        modifier = Modifier.fillMaxWidth().height(IntrinsicSize.Max),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        ActionCard(
-            title = "Privacy Preference Unknown",
-            description = "Trigger the consent banner. This triggers automatically for new users.",
-            onExecute = onShowConsent,
-            modifier = Modifier.weight(1f),
-        )
-        ActionCard(
-            title = "Preferences Opened",
-            description = "Open the Ketch Privacy Center to manage consent preferences.",
-            onExecute = onShowPreferences,
-            modifier = Modifier.weight(1f),
-        )
+        ActionCard("Privacy Preference Unknown", "Trigger the consent banner.", onShowConsent, Modifier.weight(1f))
+        ActionCard("Preferences Opened", "Open the Privacy Center.", onShowPreferences, Modifier.weight(1f))
     }
 }
 
 @Composable
-private fun ActionCard(
-    title: String,
-    description: String,
-    onExecute: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
+private fun ActionCard(title: String, description: String, onExecute: () -> Unit, modifier: Modifier = Modifier) {
     Column(
         modifier = modifier
-            .border(
-                BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
-                RoundedCornerShape(12.dp)
-            )
+            .border(BorderStroke(1.dp, MaterialTheme.colorScheme.outline), RoundedCornerShape(12.dp))
             .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.colorScheme.surface)
-            .padding(16.dp)
+            .padding(16.dp),
     ) {
-        Text(
-            text = title,
-            fontSize = 15.sp,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
+        Text(title, fontSize = 15.sp, fontWeight = FontWeight.Bold)
         Spacer(Modifier.height(8.dp))
-        Text(
-            text = description,
-            fontSize = 13.sp,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.weight(1f),
-        )
+        Text(description, fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.weight(1f))
         Spacer(Modifier.height(12.dp))
         Button(
             onClick = onExecute,
             shape = RoundedCornerShape(8.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = KetchPurple,
-                contentColor = MaterialTheme.colorScheme.onPrimary,
-            ),
-        ) {
-            Text("Execute", fontSize = 14.sp, fontWeight = FontWeight.Medium)
-        }
+            colors = ButtonDefaults.buttonColors(containerColor = KetchPurple),
+        ) { Text("Execute") }
     }
 }
 
 @Composable
-private fun EventLog(
-    entries: List<String>,
-    isDarkMode: Boolean,
-) {
+private fun EventLog(entries: List<String>, isDarkMode: Boolean) {
     val listState = rememberLazyListState()
-
     LaunchedEffect(entries.size) {
-        if (entries.isNotEmpty()) {
-            listState.animateScrollToItem(entries.size - 1)
-        }
+        if (entries.isNotEmpty()) listState.animateScrollToItem(entries.size - 1)
     }
-
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(220.dp)
-            .border(
-                BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
-                RoundedCornerShape(8.dp)
-            )
+            .height(180.dp)
+            .border(BorderStroke(1.dp, MaterialTheme.colorScheme.outline), RoundedCornerShape(8.dp))
             .clip(RoundedCornerShape(8.dp))
             .background(if (isDarkMode) DarkLogBackground else LightLogBackground)
-            .padding(12.dp)
+            .padding(12.dp),
     ) {
         if (entries.isEmpty()) {
-            Text(
-                text = "Waiting for events...",
-                fontSize = 11.sp,
-                fontFamily = FontFamily.Monospace,
-                color = if (isDarkMode) DarkLogText else LightLogText,
-            )
+            Text("Waiting for events...", fontSize = 11.sp, fontFamily = FontFamily.Monospace,
+                color = if (isDarkMode) DarkLogText else LightLogText)
         } else {
             LazyColumn(state = listState) {
                 items(entries) { entry ->
-                    Text(
-                        text = entry,
-                        fontSize = 11.sp,
-                        fontFamily = FontFamily.Monospace,
-                        color = if (isDarkMode) DarkLogText else LightLogText,
-                    )
+                    Text(entry, fontSize = 11.sp, fontFamily = FontFamily.Monospace,
+                        color = if (isDarkMode) DarkLogText else LightLogText)
                 }
             }
         }

--- a/sample-app-compose/src/main/java/com/ketch/android/sample/compose/MainActivity.kt
+++ b/sample-app-compose/src/main/java/com/ketch/android/sample/compose/MainActivity.kt
@@ -5,144 +5,372 @@ import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import com.ketch.android.Ketch
 import com.ketch.android.KetchSdk
+import com.ketch.android.api.KetchDataCenter
 import com.ketch.android.data.Consent
+import com.ketch.android.data.ConsentConfig
+import com.ketch.android.data.FullConfigurationRequest
+import com.ketch.android.data.HeadlessConfiguration
 import com.ketch.android.data.HideExperienceStatus
 import com.ketch.android.data.KetchConfig
 import com.ketch.android.data.WillShowExperienceType
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.UUID
+
+/** Flip [ENABLED] to redirect UAT tag script URLs to local dev servers. */
+private object DevUrlOverrides {
+    const val ENABLED = false
+
+    val forEmulator: Map<String, String> = mapOf(
+        "https://cdn.uat.ketchjs.com/ketchtag/stable/v2.12/ketch-sdk.js" to "http://localhost:9000/ketch-sdk.js",
+        "ketch-sdk.js" to "http://localhost:9000/ketch-sdk.js",
+    )
+
+    val forDevice: Map<String, String> = mapOf(
+        "https://cdn.uat.ketchjs.com/ketchtag/stable/v2.12/ketch-sdk.js" to "http://localhost:9000/ketch-sdk.js",
+        "ketch-sdk.js" to "http://localhost:9000/ketch-sdk.js",
+    )
+}
+
+private data class SampleDashboardState(
+    val initState: String = "Initialized",
+    val statusText: String = "Ketch initialized",
+    val loadState: String = "idle",
+    val experienceVisibility: String = "hidden",
+    val dismissReason: String = "—",
+    val environment: String = "Not set",
+    val jurisdiction: String = "Not set",
+    val region: String = "Not set",
+    val consent: String = "Not set",
+    val usPrivacy: String = "Not set",
+    val tcf: String = "Not set",
+    val gpp: String = "Not set",
+    val configSummary: String = "Not loaded",
+    val purposesSummary: String = "Not loaded",
+    val headlessLocationResult: String = "—",
+    val headlessBootstrapResult: String = "—",
+    val headlessConsentResult: String = "—",
+    val eventLog: List<String> = emptyList(),
+) {
+    fun appendLog(message: String): SampleDashboardState {
+        val line = "[${SimpleDateFormat("HH:mm:ss", Locale.US).format(Date())}] $message"
+        return copy(eventLog = (eventLog + line).takeLast(50))
+    }
+
+    fun setStatus(message: String): SampleDashboardState =
+        appendLog(message).copy(statusText = message)
+}
+
+private object HeadlessSampleSupport {
+    const val ORG_CODE = "ethansch061226"
+    const val PROPERTY = "website_smart_tag"
+    const val ENVIRONMENT = "production"
+    val dataCenter: KetchDataCenter = KetchDataCenter.UAT
+
+    fun uniqueEmailIdentity(): Map<String, String> =
+        mapOf("email" to "headless-${UUID.randomUUID()}@integration.ketch.test")
+
+    fun consentConfigFrom(
+        config: HeadlessConfiguration,
+        identities: Map<String, String>,
+    ): ConsentConfig {
+        val jurisdiction = config.jurisdiction?.code
+            ?: config.jurisdiction?.defaultJurisdictionCode
+            ?: "us"
+        val purposes = config.purposes
+            ?.mapNotNull { purpose ->
+                val code = purpose.code
+                val legalBasis = purpose.legalBasisCode
+                if (code != null && legalBasis != null) {
+                    code to ConsentConfig.PurposeLegalBasis(legalBasis)
+                } else {
+                    null
+                }
+            }
+            ?.toMap()
+            ?: emptyMap()
+        require(purposes.isNotEmpty()) { "Configuration returned no purposes" }
+        return ConsentConfig(
+            organizationCode = ORG_CODE,
+            propertyCode = PROPERTY,
+            environmentCode = ENVIRONMENT,
+            jurisdictionCode = jurisdiction,
+            identities = identities,
+            purposes = purposes,
+        )
+    }
+}
 
 class MainActivity : AppCompatActivity() {
 
     private lateinit var ketch: Ketch
-    private val logEntries = mutableStateListOf<String>()
+    private var dashboard by mutableStateOf(SampleDashboardState())
 
     companion object {
         private const val TAG = "KetchCompose"
-        private const val ORG_CODE = "ketch_samples"
-        private const val PROPERTY = "android"
+        private const val ORG_CODE = "ethansch061226"
+        private const val PROPERTY = "website_smart_tag"
         private const val ENVIRONMENT = "production"
+        private const val LANGUAGE = "en"
     }
 
     private val ketchListener = object : Ketch.Listener {
         override fun onShow() {
-            Log.d(TAG, "onShow: Dialog shown")
-            appendLog("onShow: Dialog shown")
+            Log.d(TAG, "onShow")
+            updateDashboard {
+                it.copy(experienceVisibility = "showing").appendLog("onShow")
+            }
         }
 
         override fun onDismiss(status: HideExperienceStatus) {
-            Log.d(TAG, "onDismiss: status=$status")
-            appendLog("onDismiss: status=$status")
+            updateDashboard {
+                it.copy(experienceVisibility = "dismissed", dismissReason = status.toString())
+                    .appendLog("onDismiss: $status")
+            }
         }
 
         override fun onConfigUpdated(config: KetchConfig?) {
-            Log.d(TAG, "onConfigUpdated: $config")
-            appendLog("onConfigUpdated")
+            val display = config?.experiences?.consent?.display?.name ?: "null"
+            updateDashboard {
+                it.appendLog("onConfigUpdated: experience display=$display")
+            }
+        }
+
+        override fun onConfigDebugInfo(configSummary: String, purposesSummary: String) {
+            Log.d(TAG, "config: $configSummary")
+            Log.d(TAG, "purposes: $purposesSummary")
+            updateDashboard {
+                it.copy(configSummary = configSummary, purposesSummary = purposesSummary)
+                    .appendLog("config: $configSummary")
+                    .appendLog("purposes: $purposesSummary")
+            }
         }
 
         override fun onEnvironmentUpdated(environment: String?) {
-            Log.d(TAG, "onEnvironmentUpdated: $environment")
-            appendLog("onEnvironmentUpdated: $environment")
+            updateDashboard {
+                it.copy(
+                    environment = environment ?: "Not set",
+                    loadState = "loaded",
+                ).appendLog("onEnvironmentUpdated: $environment")
+            }
         }
 
         override fun onRegionInfoUpdated(regionInfo: String?) {
-            Log.d(TAG, "onRegionInfoUpdated: $regionInfo")
-            appendLog("onRegionInfoUpdated: $regionInfo")
+            updateDashboard {
+                it.copy(region = regionInfo ?: "Not set").appendLog("onRegionInfoUpdated: $regionInfo")
+            }
         }
 
         override fun onJurisdictionUpdated(jurisdiction: String?) {
-            Log.d(TAG, "onJurisdictionUpdated: $jurisdiction")
-            appendLog("onJurisdictionUpdated: $jurisdiction")
+            updateDashboard {
+                it.copy(jurisdiction = jurisdiction ?: "Not set").appendLog("onJurisdictionUpdated: $jurisdiction")
+            }
         }
 
         override fun onIdentitiesUpdated(identities: String?) {
-            Log.d(TAG, "onIdentitiesUpdated: $identities")
-            appendLog("onIdentitiesUpdated: $identities")
+            updateDashboard { it.appendLog("onIdentitiesUpdated: $identities") }
         }
 
         override fun onConsentUpdated(consent: Consent) {
-            Log.d(TAG, "onConsentUpdated: purposes=${consent.purposes}")
-            appendLog("onConsentUpdated: ${consent.purposes}")
+            updateDashboard {
+                it.copy(consent = consent.purposes.toString()).appendLog("onConsentUpdated")
+            }
         }
 
         override fun onError(errMsg: String?) {
-            Log.e(TAG, "onError: $errMsg")
-            appendLog("ERROR: $errMsg")
+            updateDashboard {
+                it.copy(loadState = "error", initState = "Error")
+                    .setStatus("Error: ${errMsg ?: "unknown"}")
+            }
         }
 
         override fun onUSPrivacyUpdated(values: Map<String, Any?>) {
-            Log.d(TAG, "onUSPrivacyUpdated: $values")
-            appendLog("onUSPrivacyUpdated: ${values["IABUSPrivacy_String"]}")
+            updateDashboard {
+                it.copy(usPrivacy = values["IABUSPrivacy_String"]?.toString() ?: "Not set")
+                    .appendLog("onUSPrivacyUpdated")
+            }
         }
 
         override fun onTCFUpdated(values: Map<String, Any?>) {
-            Log.d(TAG, "onTCFUpdated: $values")
-            appendLog("onTCFUpdated: ${values["IABTCF_TCString"]}")
+            updateDashboard {
+                it.copy(tcf = values["IABTCF_TCString"]?.toString() ?: "Not set").appendLog("onTCFUpdated")
+            }
         }
 
         override fun onGPPUpdated(values: Map<String, Any?>) {
-            Log.d(TAG, "onGPPUpdated: $values")
-            appendLog("onGPPUpdated: ${values["IABGPP_HDR_GppString"]}")
+            updateDashboard {
+                it.copy(gpp = values["IABGPP_HDR_GppString"]?.toString() ?: "Not set").appendLog("onGPPUpdated")
+            }
         }
 
         override fun onWillShowExperience(type: WillShowExperienceType) {
-            Log.d(TAG, "onWillShowExperience: $type")
-            appendLog("onWillShowExperience: $type")
+            updateDashboard {
+                it.copy(experienceVisibility = "will show: $type").appendLog("onWillShowExperience: $type")
+            }
         }
 
         override fun onHasShownExperience() {
-            Log.d(TAG, "onHasShownExperience")
-            appendLog("onHasShownExperience")
+            updateDashboard {
+                it.copy(experienceVisibility = "shown").appendLog("onHasShownExperience")
+            }
         }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-
         initializeKetch()
 
         setContent {
             KetchSampleApp(
-                logEntries = logEntries,
+                dashboard = dashboard,
+                connectionSummary = "$ORG_CODE / $PROPERTY / $ENVIRONMENT",
+                onLoad = {
+                    updateDashboard { it.copy(loadState = "loading").setStatus("Load called") }
+                    ketch.load()
+                },
                 onShowConsent = {
-                    Log.d(TAG, "showConsent() called")
-                    appendLog("showConsent() called")
+                    updateDashboard { it.setStatus("showConsent() on ${if (dashboard.loadState == "loaded") "loaded" else "new"} WebView") }
                     ketch.showConsent()
                 },
                 onShowPreferences = {
-                    Log.d(TAG, "showPreferences() called")
-                    appendLog("showPreferences() called")
+                    updateDashboard { it.setStatus("showPreferences() called") }
                     ketch.showPreferences()
                 },
+                onSetLanguage = {
+                    ketch.setLanguage("EN")
+                    updateDashboard { it.setStatus("Language set to EN") }
+                },
+                onSetJurisdiction = {
+                    ketch.setJurisdiction("US")
+                    updateDashboard { it.setStatus("Jurisdiction set to US") }
+                },
+                onSetRegion = {
+                    ketch.setRegion("California")
+                    updateDashboard { it.setStatus("Region set to California") }
+                },
+                onHeadlessLocation = { runHeadlessLocation() },
+                onHeadlessBootstrap = { runHeadlessBootstrap() },
+                onHeadlessConsent = { runHeadlessConsent() },
             )
         }
     }
 
     private fun initializeKetch() {
         ketch = KetchSdk.create(
-            this,
-            supportFragmentManager,
-            ORG_CODE,
-            PROPERTY,
-            ENVIRONMENT,
-            ketchListener,
-            null,
-            Ketch.LogLevel.DEBUG
+            context = this,
+            fragmentManager = supportFragmentManager,
+            organization = ORG_CODE,
+            property = PROPERTY,
+            environment = ENVIRONMENT,
+            listener = ketchListener,
+            dataCenter = HeadlessSampleSupport.dataCenter,
+            logLevel = Ketch.LogLevel.DEBUG,
+            webResourceUrlOverrides = if (DevUrlOverrides.ENABLED) DevUrlOverrides.forEmulator else emptyMap(),
         )
-
-        ketch.setIdentities(mapOf("aaid" to "sample-test-123"))
-
-        appendLog("Ketch initialized")
-
-        ketch.load()
-        appendLog("load() called")
+        ketch.setIdentities(mapOf("email" to "sample-test@integration.ketch.test"))
+        ketch.setLanguage("en")
+        dashboard = dashboard.setStatus("Ketch initialized")
     }
 
-    private fun appendLog(message: String) {
-        runOnUiThread {
-            logEntries.add(message)
+    private fun updateDashboard(block: (SampleDashboardState) -> SampleDashboardState) {
+        runOnUiThread { dashboard = block(dashboard) }
+    }
+
+    private fun runHeadlessLocation() {
+        updateDashboard { it.copy(headlessLocationResult = "Loading...") }
+        KetchSdk.fetchLocation(HeadlessSampleSupport.dataCenter) { result ->
+            val text = result.fold(
+                onSuccess = { "OK: ${it.location?.countryCode ?: "?"}" },
+                onFailure = { "Error: ${it.message}" },
+            )
+            updateDashboard { it.copy(headlessLocationResult = text).appendLog("headless location: $text") }
+        }
+    }
+
+    private fun runHeadlessBootstrap() {
+        updateDashboard { it.copy(headlessBootstrapResult = "Loading...") }
+        KetchSdk.fetchBootstrapConfiguration(
+            ORG_CODE,
+            PROPERTY,
+            HeadlessSampleSupport.dataCenter,
+        ) { result ->
+            val text = result.fold(
+                onSuccess = { boot ->
+                    val jurisdiction = boot.jurisdiction?.code ?: boot.jurisdiction?.defaultJurisdictionCode ?: "?"
+                    "OK: jurisdiction=$jurisdiction purposes=${boot.purposes?.size ?: 0}"
+                },
+                onFailure = { "Error: ${it.message}" },
+            )
+            updateDashboard { it.copy(headlessBootstrapResult = text).appendLog("headless bootstrap: $text") }
+        }
+    }
+
+    private fun runHeadlessConsent() {
+        updateDashboard { it.copy(headlessConsentResult = "Loading...") }
+        val identities = HeadlessSampleSupport.uniqueEmailIdentity()
+        KetchSdk.fetchLocation(HeadlessSampleSupport.dataCenter) { _ ->
+            KetchSdk.fetchBootstrapConfiguration(
+                ORG_CODE,
+                PROPERTY,
+                HeadlessSampleSupport.dataCenter,
+            ) { bootResult ->
+                bootResult.onSuccess { boot ->
+                    val jurisdiction = boot.jurisdiction?.code
+                        ?: boot.jurisdiction?.defaultJurisdictionCode
+                    val configUrl = HeadlessSampleSupport.dataCenter.baseUrl +
+                        "/config/$ORG_CODE/$PROPERTY/$ENVIRONMENT/$jurisdiction/$LANGUAGE/config.json"
+                    updateDashboard { it.appendLog("headless config URL: $configUrl") }
+                    KetchSdk.fetchFullConfiguration(
+                        FullConfigurationRequest(
+                            organizationCode = ORG_CODE,
+                            propertyCode = PROPERTY,
+                            environmentCode = ENVIRONMENT,
+                            jurisdictionCode = jurisdiction,
+                            languageCode = LANGUAGE,
+                        ),
+                        HeadlessSampleSupport.dataCenter,
+                    ) { fullResult ->
+                        fullResult.onSuccess { full ->
+                            val purposeCodes = full.purposes?.mapNotNull { it.code } ?: emptyList()
+                            val configSummary = "headless jurisdiction=${full.jurisdiction?.code} purposes=${purposeCodes.size}"
+                            val purposesSummary = if (purposeCodes.isEmpty()) {
+                                "headless purposes: none"
+                            } else {
+                                "headless purposes: ${purposeCodes.joinToString(", ")}"
+                            }
+                            updateDashboard {
+                                it.copy(configSummary = configSummary, purposesSummary = purposesSummary)
+                                    .appendLog(configSummary)
+                                    .appendLog(purposesSummary)
+                            }
+                            val config = HeadlessSampleSupport.consentConfigFrom(full, identities)
+                            KetchSdk.fetchConsent(config, HeadlessSampleSupport.dataCenter) { consentResult ->
+                                val text = consentResult.fold(
+                                    onSuccess = {
+                                        val count = it.purposes?.size ?: it.protocols?.size ?: 0
+                                        "OK: $count item(s)"
+                                    },
+                                    onFailure = { "Error: ${it.message}" },
+                                )
+                                updateDashboard {
+                                    it.copy(headlessConsentResult = text).appendLog("headless consent: $text")
+                                }
+                            }
+                        }.onFailure { err ->
+                            updateDashboard { it.copy(headlessConsentResult = "Error: ${err.message}") }
+                        }
+                    }
+                }.onFailure { err ->
+                    updateDashboard { it.copy(headlessConsentResult = "Error: ${err.message}") }
+                }
+            }
         }
     }
 }

--- a/sample-app-compose/src/main/res/xml/network_security_config.xml
+++ b/sample-app-compose/src/main/res/xml/network_security_config.xml
@@ -3,6 +3,8 @@
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">ketchcdn.com</domain>
         <domain includeSubdomains="true">global.ketchcdn.com</domain>
+        <domain includeSubdomains="true">10.0.2.2</domain>
+        <domain includeSubdomains="true">localhost</domain>
     </domain-config>
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>

--- a/sample-app-standard/src/main/java/com/ketch/android/sample/standard/MainActivity.kt
+++ b/sample-app-standard/src/main/java/com/ketch/android/sample/standard/MainActivity.kt
@@ -11,101 +11,208 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import com.ketch.android.Ketch
 import com.ketch.android.KetchSdk
+import com.ketch.android.api.KetchDataCenter
 import com.ketch.android.data.Consent
+import com.ketch.android.data.ConsentConfig
+import com.ketch.android.data.FullConfigurationRequest
+import com.ketch.android.data.HeadlessConfiguration
 import com.ketch.android.data.HideExperienceStatus
 import com.ketch.android.data.KetchConfig
 import com.ketch.android.data.WillShowExperienceType
 import com.ketch.android.sample.standard.databinding.ActivityMainBinding
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.UUID
+
+private object DevUrlOverrides {
+    const val ENABLED = true
+
+    val forEmulator: Map<String, String> = mapOf(
+        "https://cdn.uat.ketchjs.com/ketchtag/stable/v2.12/ketch-sdk.js" to "http://localhost:9000/ketch-sdk.js",
+        "ketch-sdk.js" to "http://localhost:9000/ketch-sdk.js",
+    )
+
+    val forDevice: Map<String, String> = mapOf(
+        "https://cdn.uat.ketchjs.com/ketchtag/stable/v2.12/ketch-sdk.js" to "http://localhost:9000/ketch-sdk.js",
+        "ketch-sdk.js" to "http://localhost:9000/ketch-sdk.js",
+    )
+}
+
+private data class SampleDashboardState(
+    val initState: String = "Initialized",
+    val statusText: String = "Ketch initialized",
+    val loadState: String = "idle",
+    val experienceVisibility: String = "hidden",
+    val dismissReason: String = "—",
+    val environment: String = "Not set",
+    val jurisdiction: String = "Not set",
+    val region: String = "Not set",
+    val consent: String = "Not set",
+    val usPrivacy: String = "Not set",
+    val tcf: String = "Not set",
+    val gpp: String = "Not set",
+    val configSummary: String = "Not loaded",
+    val purposesSummary: String = "Not loaded",
+    val headlessLocationResult: String = "—",
+    val headlessBootstrapResult: String = "—",
+    val headlessConsentResult: String = "—",
+    val eventLog: List<String> = emptyList(),
+) {
+    fun appendLog(message: String): SampleDashboardState {
+        val line = "[${SimpleDateFormat("HH:mm:ss", Locale.US).format(Date())}] $message"
+        return copy(eventLog = (eventLog + line).takeLast(50))
+    }
+
+    fun setStatus(message: String): SampleDashboardState =
+        appendLog(message).copy(statusText = message)
+}
+
+private object HeadlessSampleSupport {
+    const val ORG_CODE = "ethansch061226"
+    const val PROPERTY = "website_smart_tag"
+    const val ENVIRONMENT = "production"
+    val dataCenter: KetchDataCenter = KetchDataCenter.UAT
+
+    fun uniqueEmailIdentity(): Map<String, String> =
+        mapOf("email" to "headless-${UUID.randomUUID()}@integration.ketch.test")
+
+    fun consentConfigFrom(
+        config: HeadlessConfiguration,
+        identities: Map<String, String>,
+    ): ConsentConfig {
+        val jurisdiction = config.jurisdiction?.code
+            ?: config.jurisdiction?.defaultJurisdictionCode
+            ?: "us"
+        val purposes = config.purposes
+            ?.mapNotNull { purpose ->
+                val code = purpose.code
+                val legalBasis = purpose.legalBasisCode
+                if (code != null && legalBasis != null) {
+                    code to ConsentConfig.PurposeLegalBasis(legalBasis)
+                } else {
+                    null
+                }
+            }
+            ?.toMap()
+            ?: emptyMap()
+        require(purposes.isNotEmpty()) { "Configuration returned no purposes" }
+        return ConsentConfig(
+            organizationCode = ORG_CODE,
+            propertyCode = PROPERTY,
+            environmentCode = ENVIRONMENT,
+            jurisdictionCode = jurisdiction,
+            identities = identities,
+            purposes = purposes,
+        )
+    }
+}
 
 class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding
     private lateinit var ketch: Ketch
+    private var dashboard = SampleDashboardState()
 
     companion object {
         private const val TAG = "KetchSample"
-        private const val ORG_CODE = "ketch_samples"
-        private const val PROPERTY = "android"
+        private const val ORG_CODE = "ethansch061226"
+        private const val PROPERTY = "website_smart_tag"
         private const val ENVIRONMENT = "production"
+        private const val LANGUAGE = "en"
     }
 
     private val ketchListener = object : Ketch.Listener {
         override fun onShow() {
-            Log.d(TAG, "onShow: Dialog shown")
-            appendLog("onShow: Dialog shown")
+            updateDashboard {
+                it.copy(experienceVisibility = "showing").appendLog("onShow")
+            }
         }
 
         override fun onDismiss(status: HideExperienceStatus) {
-            Log.d(TAG, "onDismiss: status=$status")
-            appendLog("onDismiss: status=$status")
+            updateDashboard {
+                it.copy(experienceVisibility = "dismissed", dismissReason = status.toString())
+                    .appendLog("onDismiss: $status")
+            }
         }
 
         override fun onConfigUpdated(config: KetchConfig?) {
-            Log.d(TAG, "onConfigUpdated: $config")
-            appendLog("onConfigUpdated")
+            updateDashboard { it.appendLog("onConfigUpdated") }
         }
 
         override fun onEnvironmentUpdated(environment: String?) {
-            Log.d(TAG, "onEnvironmentUpdated: $environment")
-            appendLog("onEnvironmentUpdated: $environment")
+            updateDashboard {
+                it.copy(
+                    environment = environment ?: "Not set",
+                    loadState = "loaded",
+                ).appendLog("onEnvironmentUpdated: $environment")
+            }
         }
 
         override fun onRegionInfoUpdated(regionInfo: String?) {
-            Log.d(TAG, "onRegionInfoUpdated: $regionInfo")
-            appendLog("onRegionInfoUpdated: $regionInfo")
+            updateDashboard {
+                it.copy(region = regionInfo ?: "Not set").appendLog("onRegionInfoUpdated: $regionInfo")
+            }
         }
 
         override fun onJurisdictionUpdated(jurisdiction: String?) {
-            Log.d(TAG, "onJurisdictionUpdated: $jurisdiction")
-            appendLog("onJurisdictionUpdated: $jurisdiction")
+            updateDashboard {
+                it.copy(jurisdiction = jurisdiction ?: "Not set").appendLog("onJurisdictionUpdated: $jurisdiction")
+            }
         }
 
         override fun onIdentitiesUpdated(identities: String?) {
-            Log.d(TAG, "onIdentitiesUpdated: $identities")
-            appendLog("onIdentitiesUpdated: $identities")
+            updateDashboard { it.appendLog("onIdentitiesUpdated: $identities") }
         }
 
         override fun onConsentUpdated(consent: Consent) {
-            Log.d(TAG, "onConsentUpdated: purposes=${consent.purposes}")
-            appendLog("onConsentUpdated: ${consent.purposes}")
+            updateDashboard {
+                it.copy(consent = consent.purposes.toString()).appendLog("onConsentUpdated")
+            }
         }
 
         override fun onError(errMsg: String?) {
-            Log.e(TAG, "onError: $errMsg")
-            appendLog("ERROR: $errMsg")
+            updateDashboard {
+                it.copy(loadState = "error", initState = "Error")
+                    .setStatus("Error: ${errMsg ?: "unknown"}")
+            }
         }
 
         override fun onUSPrivacyUpdated(values: Map<String, Any?>) {
-            Log.d(TAG, "onUSPrivacyUpdated: $values")
-            appendLog("onUSPrivacyUpdated: ${values["IABUSPrivacy_String"]}")
+            updateDashboard {
+                it.copy(usPrivacy = values["IABUSPrivacy_String"]?.toString() ?: "Not set")
+                    .appendLog("onUSPrivacyUpdated")
+            }
         }
 
         override fun onTCFUpdated(values: Map<String, Any?>) {
-            Log.d(TAG, "onTCFUpdated: $values")
-            appendLog("onTCFUpdated: ${values["IABTCF_TCString"]}")
+            updateDashboard {
+                it.copy(tcf = values["IABTCF_TCString"]?.toString() ?: "Not set").appendLog("onTCFUpdated")
+            }
         }
 
         override fun onGPPUpdated(values: Map<String, Any?>) {
-            Log.d(TAG, "onGPPUpdated: $values")
-            appendLog("onGPPUpdated: ${values["IABGPP_HDR_GppString"]}")
+            updateDashboard {
+                it.copy(gpp = values["IABGPP_HDR_GppString"]?.toString() ?: "Not set").appendLog("onGPPUpdated")
+            }
         }
 
         override fun onWillShowExperience(type: WillShowExperienceType) {
-            Log.d(TAG, "onWillShowExperience: $type")
-            appendLog("onWillShowExperience: $type")
+            updateDashboard {
+                it.copy(experienceVisibility = "will show: $type").appendLog("onWillShowExperience: $type")
+            }
         }
 
         override fun onHasShownExperience() {
-            Log.d(TAG, "onHasShownExperience")
-            appendLog("onHasShownExperience")
+            updateDashboard {
+                it.copy(experienceVisibility = "shown").appendLog("onHasShownExperience")
+            }
         }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         WindowCompat.setDecorFitsSystemWindows(window, false)
-
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
@@ -126,12 +233,12 @@ class MainActivity : AppCompatActivity() {
         setupDarkModeToggle()
         initializeKetch()
         setupClickListeners()
+        renderDashboard()
     }
 
     private fun setupDarkModeToggle() {
         val isNightMode = AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES
         binding.darkModeSwitch.isChecked = isNightMode
-
         binding.darkModeSwitch.setOnCheckedChangeListener { _, isChecked ->
             AppCompatDelegate.setDefaultNightMode(
                 if (isChecked) AppCompatDelegate.MODE_NIGHT_YES
@@ -142,45 +249,159 @@ class MainActivity : AppCompatActivity() {
 
     private fun initializeKetch() {
         ketch = KetchSdk.create(
-            this,
-            supportFragmentManager,
-            ORG_CODE,
-            PROPERTY,
-            ENVIRONMENT,
-            ketchListener,
-            null,
-            Ketch.LogLevel.DEBUG
+            context = this,
+            fragmentManager = supportFragmentManager,
+            organization = ORG_CODE,
+            property = PROPERTY,
+            environment = ENVIRONMENT,
+            listener = ketchListener,
+            dataCenter = HeadlessSampleSupport.dataCenter,
+            logLevel = Ketch.LogLevel.DEBUG,
+            webResourceUrlOverrides = if (DevUrlOverrides.ENABLED) DevUrlOverrides.forEmulator else emptyMap(),
         )
-
-        ketch.setIdentities(mapOf("aaid" to "sample-test-123"))
-
-        appendLog("Ketch initialized")
-
-        ketch.load()
-        appendLog("load() called")
+        ketch.setIdentities(mapOf("email" to "sample-test@integration.ketch.test"))
+        ketch.setLanguage("en")
+        dashboard = dashboard.setStatus("Ketch initialized")
     }
 
     private fun setupClickListeners() {
-        binding.showConsentButton.setOnClickListener {
+        val showConsent = {
             Log.d(TAG, "showConsent() called")
-            appendLog("showConsent() called")
+            updateDashboard { it.setStatus("showConsent() called") }
             ketch.showConsent()
         }
-
-        binding.showPreferencesButton.setOnClickListener {
+        val showPreferences = {
             Log.d(TAG, "showPreferences() called")
-            appendLog("showPreferences() called")
+            updateDashboard { it.setStatus("showPreferences() called") }
             ketch.showPreferences()
+        }
+
+        binding.loadButton.setOnClickListener {
+            updateDashboard { it.copy(loadState = "loading").setStatus("Load called") }
+            ketch.load()
+        }
+        binding.showConsentButton.setOnClickListener { showConsent() }
+        binding.showPreferencesButton.setOnClickListener { showPreferences() }
+        binding.showConsentCardButton.setOnClickListener { showConsent() }
+        binding.showPreferencesCardButton.setOnClickListener { showPreferences() }
+
+        binding.setLanguageButton.setOnClickListener {
+            ketch.setLanguage("EN")
+            updateDashboard { it.setStatus("Language set to EN") }
+        }
+        binding.setJurisdictionButton.setOnClickListener {
+            ketch.setJurisdiction("US")
+            updateDashboard { it.setStatus("Jurisdiction set to US") }
+        }
+        binding.setRegionButton.setOnClickListener {
+            ketch.setRegion("California")
+            updateDashboard { it.setStatus("Region set to California") }
+        }
+
+        binding.headlessLocationButton.setOnClickListener { runHeadlessLocation() }
+        binding.headlessBootstrapButton.setOnClickListener { runHeadlessBootstrap() }
+        binding.headlessConsentButton.setOnClickListener { runHeadlessConsent() }
+    }
+
+    private fun updateDashboard(block: (SampleDashboardState) -> SampleDashboardState) {
+        runOnUiThread {
+            dashboard = block(dashboard)
+            renderDashboard()
         }
     }
 
-    private fun appendLog(message: String) {
-        runOnUiThread {
-            val current = binding.eventLogText.text.toString()
-            val prefix = if (current == "Waiting for events...") "" else "$current\n"
-            binding.eventLogText.text = "$prefix$message"
-            binding.eventLogScroll.post {
-                binding.eventLogScroll.fullScroll(ScrollView.FOCUS_DOWN)
+    private fun renderDashboard() {
+        binding.initText.text = "Init: ${dashboard.initState}"
+        binding.statusText.text = "Status: ${dashboard.statusText}"
+        binding.connectionText.text = "Connection: $ORG_CODE / $PROPERTY / $ENVIRONMENT"
+        binding.loadStateText.text = "Load: ${dashboard.loadState}"
+        binding.visibilityText.text = "Visibility: ${dashboard.experienceVisibility}"
+        binding.dismissText.text = "Dismiss: ${dashboard.dismissReason}"
+        binding.environmentText.text = "Environment: ${dashboard.environment}"
+        binding.jurisdictionText.text = "Jurisdiction: ${dashboard.jurisdiction}"
+        binding.regionText.text = "Region: ${dashboard.region}"
+        binding.consentText.text = "Consent: ${truncate(dashboard.consent)}"
+        binding.usPrivacyText.text = "US Privacy: ${truncate(dashboard.usPrivacy)}"
+        binding.tcfText.text = "TCF: ${truncate(dashboard.tcf)}"
+        binding.gppText.text = "GPP: ${truncate(dashboard.gpp)}"
+        binding.headlessLocationText.text = "Location: ${dashboard.headlessLocationResult}"
+        binding.headlessBootstrapText.text = "Bootstrap: ${dashboard.headlessBootstrapResult}"
+        binding.headlessConsentText.text = "Consent: ${dashboard.headlessConsentResult}"
+
+        binding.eventLogText.text = if (dashboard.eventLog.isEmpty()) {
+            "Waiting for events..."
+        } else {
+            dashboard.eventLog.joinToString("\n")
+        }
+        binding.eventLogScroll.post {
+            binding.eventLogScroll.fullScroll(ScrollView.FOCUS_DOWN)
+        }
+    }
+
+    private fun truncate(value: String, max: Int = 80): String =
+        if (value.length <= max) value else "${value.take(max)}…"
+
+    private fun runHeadlessLocation() {
+        updateDashboard { it.copy(headlessLocationResult = "Loading...") }
+        KetchSdk.fetchLocation(HeadlessSampleSupport.dataCenter) { result ->
+            val text = result.fold(
+                onSuccess = { "OK: ${it.location?.countryCode ?: "?"}" },
+                onFailure = { "Error: ${it.message}" },
+            )
+            updateDashboard { it.copy(headlessLocationResult = text).appendLog("headless location: $text") }
+        }
+    }
+
+    private fun runHeadlessBootstrap() {
+        updateDashboard { it.copy(headlessBootstrapResult = "Loading...") }
+        KetchSdk.fetchBootstrapConfiguration(ORG_CODE, PROPERTY, HeadlessSampleSupport.dataCenter) { result ->
+            val text = result.fold(
+                onSuccess = { "OK: ${it.purposes?.size ?: 0} purpose(s)" },
+                onFailure = { "Error: ${it.message}" },
+            )
+            updateDashboard { it.copy(headlessBootstrapResult = text).appendLog("headless bootstrap: $text") }
+        }
+    }
+
+    private fun runHeadlessConsent() {
+        updateDashboard { it.copy(headlessConsentResult = "Loading...") }
+        val identities = HeadlessSampleSupport.uniqueEmailIdentity()
+        KetchSdk.fetchLocation(HeadlessSampleSupport.dataCenter) { _ ->
+            KetchSdk.fetchBootstrapConfiguration(ORG_CODE, PROPERTY, HeadlessSampleSupport.dataCenter) { bootResult ->
+                bootResult.onSuccess { boot ->
+                    val jurisdiction = boot.jurisdiction?.code
+                        ?: boot.jurisdiction?.defaultJurisdictionCode
+                    KetchSdk.fetchFullConfiguration(
+                        FullConfigurationRequest(
+                            organizationCode = ORG_CODE,
+                            propertyCode = PROPERTY,
+                            environmentCode = ENVIRONMENT,
+                            jurisdictionCode = jurisdiction,
+                            languageCode = LANGUAGE,
+                        ),
+                        HeadlessSampleSupport.dataCenter,
+                    ) { fullResult ->
+                        fullResult.onSuccess { full ->
+                            val config = HeadlessSampleSupport.consentConfigFrom(full, identities)
+                            KetchSdk.fetchConsent(config, HeadlessSampleSupport.dataCenter) { consentResult ->
+                                val text = consentResult.fold(
+                                    onSuccess = {
+                                        val count = it.purposes?.size ?: it.protocols?.size ?: 0
+                                        "OK: $count item(s)"
+                                    },
+                                    onFailure = { "Error: ${it.message}" },
+                                )
+                                updateDashboard {
+                                    it.copy(headlessConsentResult = text).appendLog("headless consent: $text")
+                                }
+                            }
+                        }.onFailure { err ->
+                            updateDashboard { it.copy(headlessConsentResult = "Error: ${err.message}") }
+                        }
+                    }
+                }.onFailure { err ->
+                    updateDashboard { it.copy(headlessConsentResult = "Error: ${err.message}") }
+                }
             }
         }
     }

--- a/sample-app-standard/src/main/res/layout/activity_main.xml
+++ b/sample-app-standard/src/main/res/layout/activity_main.xml
@@ -9,7 +9,6 @@
     android:background="@color/background"
     tools:context=".MainActivity">
 
-    <!-- Header bar -->
     <LinearLayout
         android:id="@+id/headerBar"
         android:layout_width="match_parent"
@@ -29,26 +28,12 @@
             android:textColor="@color/text_primary"
             android:fontFamily="sans-serif-medium" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="☀️"
-            android:textSize="16sp"
-            android:layout_marginEnd="4dp" />
-
         <com.google.android.material.switchmaterial.SwitchMaterial
             android:id="@+id/darkModeSwitch"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:trackTint="@color/toggle_track"
             app:thumbTint="@color/toggle_thumb" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="🌙"
-            android:textSize="16sp"
-            android:layout_marginStart="4dp" />
 
     </LinearLayout>
 
@@ -70,138 +55,74 @@
             android:orientation="vertical"
             android:padding="20dp">
 
-            <!-- Section header -->
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Experience Functions"
+                android:text="SDK Health Dashboard"
                 android:textSize="18sp"
                 android:textStyle="bold"
                 android:textColor="@color/ketch_purple"
-                android:drawableStart="@android:drawable/arrow_down_float"
-                android:drawablePadding="4dp"
-                android:drawableTint="@color/ketch_purple"
-                android:layout_marginBottom="16dp" />
-
-            <!-- Cards row -->
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:layout_marginBottom="24dp"
-                android:baselineAligned="false">
-
-                <!-- Privacy Preference Unknown card -->
-                <LinearLayout
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:orientation="vertical"
-                    android:background="@drawable/card_background"
-                    android:padding="16dp"
-                    android:layout_marginEnd="8dp">
-
-                    <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="Privacy Preference Unknown"
-                        android:textSize="15sp"
-                        android:textStyle="bold"
-                        android:textColor="@color/text_primary"
-                        android:layout_marginBottom="8dp" />
-
-                    <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="0dp"
-                        android:layout_weight="1"
-                        android:text="Trigger the consent banner. This triggers automatically for new users."
-                        android:textSize="13sp"
-                        android:textColor="@color/text_secondary"
-                        android:layout_marginBottom="12dp" />
-
-                    <Button
-                        android:id="@+id/showConsentButton"
-                        style="@style/Widget.KetchSample.Button.Execute"
-                        android:layout_width="wrap_content"
-                        android:layout_height="40dp"
-                        android:text="Execute" />
-
-                </LinearLayout>
-
-                <!-- Preferences Opened card -->
-                <LinearLayout
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:orientation="vertical"
-                    android:background="@drawable/card_background"
-                    android:padding="16dp"
-                    android:layout_marginStart="8dp">
-
-                    <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="Preferences Opened"
-                        android:textSize="15sp"
-                        android:textStyle="bold"
-                        android:textColor="@color/text_primary"
-                        android:layout_marginBottom="8dp" />
-
-                    <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="0dp"
-                        android:layout_weight="1"
-                        android:text="Open the Ketch Privacy Center to manage consent preferences."
-                        android:textSize="13sp"
-                        android:textColor="@color/text_secondary"
-                        android:layout_marginBottom="12dp" />
-
-                    <Button
-                        android:id="@+id/showPreferencesButton"
-                        style="@style/Widget.KetchSample.Button.Execute"
-                        android:layout_width="wrap_content"
-                        android:layout_height="40dp"
-                        android:text="Execute" />
-
-                </LinearLayout>
-
-            </LinearLayout>
-
-            <!-- Event Log section -->
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Event Log"
-                android:textSize="18sp"
-                android:textStyle="bold"
-                android:textColor="@color/ketch_purple"
-                android:drawableStart="@android:drawable/arrow_down_float"
-                android:drawablePadding="4dp"
-                android:drawableTint="@color/ketch_purple"
                 android:layout_marginBottom="12dp" />
 
-            <ScrollView
-                android:id="@+id/eventLogScroll"
-                android:layout_width="match_parent"
-                android:layout_height="220dp"
-                android:background="@drawable/log_background"
-                android:fillViewport="true">
+            <TextView android:id="@+id/initText" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Init: Initialized" android:textSize="12sp" android:fontFamily="monospace" android:layout_marginBottom="2dp" />
+            <TextView android:id="@+id/statusText" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Status: Ketch initialized" android:textSize="12sp" android:fontFamily="monospace" android:layout_marginBottom="2dp" />
+            <TextView android:id="@+id/connectionText" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Connection: ketch_samples / android / production" android:textSize="12sp" android:fontFamily="monospace" android:layout_marginBottom="2dp" />
+            <TextView android:id="@+id/loadStateText" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Load: idle" android:textSize="12sp" android:fontFamily="monospace" android:layout_marginBottom="2dp" />
+            <TextView android:id="@+id/visibilityText" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Visibility: hidden" android:textSize="12sp" android:fontFamily="monospace" android:layout_marginBottom="2dp" />
+            <TextView android:id="@+id/dismissText" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Dismiss: —" android:textSize="12sp" android:fontFamily="monospace" android:layout_marginBottom="12dp" />
 
-                <TextView
-                    android:id="@+id/eventLogText"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="Waiting for events..."
-                    android:padding="12dp"
-                    android:textSize="11sp"
-                    android:fontFamily="monospace"
-                    android:textColor="@color/log_text"
-                    android:gravity="bottom" />
+            <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Privacy / Consent State" android:textSize="16sp" android:textStyle="bold" android:textColor="@color/ketch_purple" android:layout_marginBottom="8dp" />
+            <TextView android:id="@+id/environmentText" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Environment: Not set" android:textSize="12sp" android:fontFamily="monospace" android:layout_marginBottom="2dp" />
+            <TextView android:id="@+id/jurisdictionText" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Jurisdiction: Not set" android:textSize="12sp" android:fontFamily="monospace" android:layout_marginBottom="2dp" />
+            <TextView android:id="@+id/regionText" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Region: Not set" android:textSize="12sp" android:fontFamily="monospace" android:layout_marginBottom="2dp" />
+            <TextView android:id="@+id/consentText" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Consent: Not set" android:textSize="12sp" android:fontFamily="monospace" android:layout_marginBottom="2dp" />
+            <TextView android:id="@+id/usPrivacyText" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="US Privacy: Not set" android:textSize="12sp" android:fontFamily="monospace" android:layout_marginBottom="2dp" />
+            <TextView android:id="@+id/tcfText" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="TCF: Not set" android:textSize="12sp" android:fontFamily="monospace" android:layout_marginBottom="2dp" />
+            <TextView android:id="@+id/gppText" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="GPP: Not set" android:textSize="12sp" android:fontFamily="monospace" android:layout_marginBottom="12dp" />
 
+            <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Actions" android:textSize="16sp" android:textStyle="bold" android:textColor="@color/ketch_purple" android:layout_marginBottom="8dp" />
+            <LinearLayout android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="horizontal" android:layout_marginBottom="8dp">
+                <Button android:id="@+id/loadButton" style="@style/Widget.KetchSample.Button.Execute" android:layout_width="wrap_content" android:layout_height="40dp" android:text="Load" android:layout_marginEnd="8dp" />
+                <Button android:id="@+id/showConsentButton" style="@style/Widget.KetchSample.Button.Execute" android:layout_width="wrap_content" android:layout_height="40dp" android:text="Show Consent" android:layout_marginEnd="8dp" />
+                <Button android:id="@+id/showPreferencesButton" style="@style/Widget.KetchSample.Button.Execute" android:layout_width="wrap_content" android:layout_height="40dp" android:text="Show Preferences" />
+            </LinearLayout>
+            <LinearLayout android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="horizontal" android:layout_marginBottom="12dp">
+                <Button android:id="@+id/setLanguageButton" style="@style/Widget.KetchSample.Button.Execute" android:layout_width="wrap_content" android:layout_height="40dp" android:text="Set Language EN" android:layout_marginEnd="8dp" />
+                <Button android:id="@+id/setJurisdictionButton" style="@style/Widget.KetchSample.Button.Execute" android:layout_width="wrap_content" android:layout_height="40dp" android:text="Set Jurisdiction US" android:layout_marginEnd="8dp" />
+                <Button android:id="@+id/setRegionButton" style="@style/Widget.KetchSample.Button.Execute" android:layout_width="wrap_content" android:layout_height="40dp" android:text="Set Region CA" />
+            </LinearLayout>
+
+            <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Headless (live CDN)" android:textSize="16sp" android:textStyle="bold" android:textColor="@color/ketch_purple" android:layout_marginBottom="8dp" />
+            <TextView android:id="@+id/headlessLocationText" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Location: —" android:textSize="12sp" android:fontFamily="monospace" android:layout_marginBottom="2dp" />
+            <TextView android:id="@+id/headlessBootstrapText" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Bootstrap: —" android:textSize="12sp" android:fontFamily="monospace" android:layout_marginBottom="2dp" />
+            <TextView android:id="@+id/headlessConsentText" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Consent: —" android:textSize="12sp" android:fontFamily="monospace" android:layout_marginBottom="8dp" />
+            <LinearLayout android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="horizontal" android:layout_marginBottom="16dp">
+                <Button android:id="@+id/headlessLocationButton" style="@style/Widget.KetchSample.Button.Execute" android:layout_width="wrap_content" android:layout_height="40dp" android:text="Fetch Location" android:layout_marginEnd="8dp" />
+                <Button android:id="@+id/headlessBootstrapButton" style="@style/Widget.KetchSample.Button.Execute" android:layout_width="wrap_content" android:layout_height="40dp" android:text="Fetch Bootstrap" android:layout_marginEnd="8dp" />
+                <Button android:id="@+id/headlessConsentButton" style="@style/Widget.KetchSample.Button.Execute" android:layout_width="wrap_content" android:layout_height="40dp" android:text="Cold Start" />
+            </LinearLayout>
+
+            <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Experience Functions" android:textSize="18sp" android:textStyle="bold" android:textColor="@color/ketch_purple" android:layout_marginBottom="16dp" />
+
+            <LinearLayout android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="horizontal" android:layout_marginBottom="24dp" android:baselineAligned="false">
+                <LinearLayout android:layout_width="0dp" android:layout_height="match_parent" android:layout_weight="1" android:orientation="vertical" android:background="@drawable/card_background" android:padding="16dp" android:layout_marginEnd="8dp">
+                    <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Privacy Preference Unknown" android:textSize="15sp" android:textStyle="bold" android:textColor="@color/text_primary" android:layout_marginBottom="8dp" />
+                    <TextView android:layout_width="match_parent" android:layout_height="0dp" android:layout_weight="1" android:text="Trigger the consent banner." android:textSize="13sp" android:textColor="@color/text_secondary" android:layout_marginBottom="12dp" />
+                    <Button android:id="@+id/showConsentCardButton" style="@style/Widget.KetchSample.Button.Execute" android:layout_width="wrap_content" android:layout_height="40dp" android:text="Execute" />
+                </LinearLayout>
+                <LinearLayout android:layout_width="0dp" android:layout_height="match_parent" android:layout_weight="1" android:orientation="vertical" android:background="@drawable/card_background" android:padding="16dp" android:layout_marginStart="8dp">
+                    <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Preferences Opened" android:textSize="15sp" android:textStyle="bold" android:textColor="@color/text_primary" android:layout_marginBottom="8dp" />
+                    <TextView android:layout_width="match_parent" android:layout_height="0dp" android:layout_weight="1" android:text="Open the Privacy Center." android:textSize="13sp" android:textColor="@color/text_secondary" android:layout_marginBottom="12dp" />
+                    <Button android:id="@+id/showPreferencesCardButton" style="@style/Widget.KetchSample.Button.Execute" android:layout_width="wrap_content" android:layout_height="40dp" android:text="Execute" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <TextView android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Event Log" android:textSize="18sp" android:textStyle="bold" android:textColor="@color/ketch_purple" android:layout_marginBottom="12dp" />
+
+            <ScrollView android:id="@+id/eventLogScroll" android:layout_width="match_parent" android:layout_height="220dp" android:background="@drawable/log_background" android:fillViewport="true">
+                <TextView android:id="@+id/eventLogText" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Waiting for events..." android:padding="12dp" android:textSize="11sp" android:fontFamily="monospace" android:textColor="@color/log_text" android:gravity="bottom" />
             </ScrollView>
 
         </LinearLayout>
-
     </ScrollView>
-
 </LinearLayout>

--- a/sample-app-standard/src/main/res/xml/network_security_config.xml
+++ b/sample-app-standard/src/main/res/xml/network_security_config.xml
@@ -3,6 +3,8 @@
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">ketchcdn.com</domain>
         <domain includeSubdomains="true">global.ketchcdn.com</domain>
+        <domain includeSubdomains="true">10.0.2.2</domain>
+        <domain includeSubdomains="true">localhost</domain>
     </domain-config>
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,6 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
 rootProject.name = "KetchSDK"
 include ':ketchsdk'
 include ':integration-tests'


### PR DESCRIPTION
## Description of this change

HeadlessApiClient, models, Ketch.kt headless methods, integration tests, and sample dashboard wiring.

Stacked on android native-storage PR (slice 2/2 replacing #117).

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

HeadlessApiClientTest, integration tests, sample apps.

## Related issues

Refs partial stack replacing #117.

## Checklist
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

## Review Notes

Pre-bot self-review on slice diff: no BLOCKER findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consent read/write and CDN HTTP paths (privacy-critical) and changes WebView dismiss/show-consent behavior; mitigated by tests and server-computed protocols on set.
> 
> **Overview**
> Adds a **native headless HTTP layer** (OkHttp + coroutines) for web/v3 CDN calls before WebView load: location, bootstrap/full config, consent get/set (protocols from server; omitted on update), plus rights, profile, subscriptions, QR URL, and telemetry. **`KetchDataCenter`** (US/EU/UAT) drives CDN base URLs; **`KetchSdk.create`** gains optional `dataCenter` and **`webResourceUrlOverrides`** for local tag dev.
> 
> **`Ketch`** exposes the same headless APIs on the instance (org/property bound) and static **`KetchSdk`** helpers with an optional data center. WebView path changes include default URL from data center, rewritten index HTML (event binding, auto-show consent, URL overrides in JS), tap-outside dismissal delegated to the tag with a timeout fallback, **`showConsent`** on an existing WebView, banner backdrop fix, and **`onConfigDebugInfo`**.
> 
> **Tests/docs/samples:** unit tests for URLs and consent payloads, **`KetchHeadlessIntegrationTest`** against live CDN, README headless section, and sample apps with health dashboards and headless buttons. Cleartext **`localhost`** allowed in sample network security config for dev overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d940ccf31e6429f1808219a056f788ef9f428b9b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->