### PR TITLE
feat: add run-sample Cursor skills

### DIFF
--- a/.cursor/rules/development-workflow.mdc
+++ b/.cursor/rules/development-workflow.mdc
@@ -1,0 +1,80 @@
+---
+alwaysApply: true
+---
+
+# Development Workflow — Ketch Android SDK
+
+## Prerequisites
+
+- **Android Studio** or Android SDK with API 24+
+- **JDK 17** (per Gradle config)
+- Emulator or device with `adb` on `PATH`
+
+## Sample apps
+
+| Module | UI stack | Manual QA entry |
+| --- | --- | --- |
+| `sample-app-compose` | Jetpack Compose | `MainActivity` + `KetchSampleApp` |
+| `sample-app-standard` | XML + ViewBinding | `activity_main.xml` + `MainActivity` |
+| `integration-tests` | XML (Espresso host) | Automation only; layout reference for dashboard |
+
+Build and run a sample:
+
+```bash
+bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh compose local
+bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh standard local
+```
+
+See `ketch-android-run-sample` skill for prerequisites, remote/local SDK toggle, and manual QA checklist.
+
+## Common Commands
+
+| Command | Purpose |
+| --- | --- |
+| `./gradlew :ketchsdk:test` | Unit tests for the SDK module |
+| `./gradlew :sample-app-compose:assembleDebug` | Build Compose sample |
+| `./gradlew :sample-app-standard:assembleDebug` | Build standard sample |
+| `bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh compose local` | Build, install, launch Compose sample (local SDK) |
+| `bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh standard local` | Build, install, launch standard sample (local SDK) |
+| `./gradlew :integration-tests:connectedDebugAndroidTest` | On-device integration tests (requires emulator) |
+
+## SDK Health Dashboard (manual QA)
+
+Both `sample-app-compose` and `sample-app-standard` include an on-screen **SDK Health Dashboard** (pattern from `integration-tests`).
+
+| Section | What to verify |
+| --- | --- |
+| **Connection** | Init, status, `ethansch061226` / `website_smart_tag` / `production` |
+| **WebView / Experience** | Load state, visibility, dismiss reason (ATT N/A on Android) |
+| **Privacy / Consent** | Environment, jurisdiction, region, consent, US Privacy / TCF / GPP |
+| **Headless** | **Fetch Location**, **Fetch Bootstrap**, **Cold Start** — inline OK/Error |
+| **Event log** | Timestamped callback trace (~50 lines) |
+
+Manual golden path: **Load** → privacy fields update → **Show Consent** → visibility/dismiss rows change → **Fetch Bootstrap** shows success or error on-screen.
+
+Defaults: org `ethansch061226`, property `website_smart_tag`, environment `production` (constants in `MainActivity`; editable org/property UI is a future enhancement).
+
+## Local tag URL overrides (non-prod scripts)
+
+Use `webResourceUrlOverrides` to redirect exact CDN URLs (e.g. UAT `plugins.js` / `ketch.js`) to local dev servers. This is separate from `dataCenter` / `ketchUrl`, which control the boot.js base path.
+
+```kotlin
+KetchSdk.create(
+    // ...
+    webResourceUrlOverrides = mapOf(
+        "https://cdn.uat.ketchjs.com/ketchtag/stable/v2.12/ketch-sdk.js" to "http://localhost:9000/ketch-sdk.js",
+    ),
+)
+// or after create:
+ketch.setWebResourceUrlOverrides(overrides)
+```
+
+Android uses native `shouldInterceptRequest` plus a JS hook in index HTML. Sample apps: set `DevUrlOverrides.ENABLED = true` in `DevUrlOverrides.kt`.
+
+## Validation Checklist
+
+Before merging SDK changes:
+
+1. `./gradlew :ketchsdk:test` — must pass
+2. Build affected sample module(s)
+3. If headless or listener contracts changed: run `integration-tests` on emulator

--- a/.cursor/skills/ketch-android-run-sample/SKILL.md
+++ b/.cursor/skills/ketch-android-run-sample/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: ketch-android-run-sample
+description: Configures the in-repo Android sample apps (Compose or standard) for either the published com.ketch.android:ketchsdk Maven artifact or the local :ketchsdk module, boots an emulator when needed, builds, installs, launches, and streams filtered logcat. Use when the user runs /ketch-android-run-sample or wants manual SDK Health Dashboard QA on Android.
+---
+
+# ketch-android-run-sample
+
+## Instructions
+
+When the user invokes **`/ketch-android-run-sample`** (or asks to run the Android sample with production / local SDK):
+
+1. `cd` to the `ketch-android` repository root.
+
+2. Run the helper script with a **required** sample variant:
+
+**Local SDK (default for SDK development)** — sample `build.gradle` uses `project(':ketchsdk')`:
+
+```bash
+bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh compose local
+bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh standard local
+```
+
+**Published Maven artifact** — sample depends on `com.ketch.android:ketchsdk` (version from `KETCH_ANDROID_SDK_VERSION` or `3.0`):
+
+```bash
+bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh compose
+bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh standard
+```
+
+The script boots an emulator when no `adb` device is connected, runs `./gradlew :sample-app-*:assembleDebug`, installs the APK, launches `MainActivity`, and streams filtered logcat (`Ketch`, sample tag). Stop with `Ctrl-C`.
+
+## Manual testing basics
+
+**Needs:** Android Studio or SDK, emulator or USB device, `adb` on PATH, network for CDN/headless steps.
+
+**Launch:** `bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh compose local` from the `ketch-android` repo root.
+
+**In the app:** **SDK Health Dashboard** is the first section in the scroll view. Connection row uses org `ethansch061226`, property `website_smart_tag`, environment `production`. Use dashboard panels and event log — logcat from the script is optional for smoke QA.
+
+**Smoke flow:** **Load** → privacy rows update → **Show Consent** → visibility/dismiss rows change → **Fetch Bootstrap** under Headless. ATT does not apply on Android.
+
+## Other options
+
+```bash
+DEVICE_ID=emulator-5554 bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh compose local
+AVD_NAME="Pixel_7_API_34" bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh standard local
+KETCH_ANDROID_SDK_VERSION=3.0 bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh compose
+bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh compose local --build-only
+bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh standard local --full-system-logs
+```
+
+## Manual QA checklist (SDK Health Dashboard)
+
+Verify on-screen panels (no logcat required):
+
+1. **Connection** — Init/status; connection row shows `ethansch061226 / website_smart_tag / production`.
+2. **Load** — Tap **Load** → Load row `loading`; environment/consent fields update from callbacks.
+3. **WebView / Experience** — **Show Consent** → visibility/dismiss rows change (ATT N/A on Android).
+4. **Privacy / Consent** — Environment, jurisdiction, region, consent, US Privacy / TCF / GPP populate after load.
+5. **Headless** — **Fetch Location**, **Fetch Bootstrap**, **Cold Start** show inline OK/Error.
+6. **Event log** — Timestamped trace (~50 lines max).
+
+## Notes
+
+- `integration-tests` is the Espresso automation host; use **compose** or **standard** samples for manual QA.
+- Headless steps require network access to the live Ketch CDN.
+- Remote mode needs the pinned Maven artifact to be resolvable from your configured repositories.

--- a/.cursor/skills/ketch-android-run-sample/scripts/configure-sample-dependency.py
+++ b/.cursor/skills/ketch-android-run-sample/scripts/configure-sample-dependency.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Switch sample apps between the local :ketchsdk project and a published Maven artifact."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+GROUP = "com.ketch.android"
+ARTIFACT = "ketchsdk"
+DEFAULT_VERSION = "3.0"
+
+SAMPLE_GRADLE_FILES = (
+    "sample-app-compose/build.gradle",
+    "sample-app-standard/build.gradle",
+)
+
+LOCAL_DEP = "implementation project(':ketchsdk')"
+REMOTE_DEP_TEMPLATE = "implementation '{group}:{artifact}:{version}'"
+
+
+def remote_dep(version: str) -> str:
+    return REMOTE_DEP_TEMPLATE.format(group=GROUP, artifact=ARTIFACT, version=version)
+
+
+def configure_file(path: Path, mode: str, version: str) -> bool:
+    text = path.read_text(encoding="utf-8")
+    target = LOCAL_DEP if mode == "local" else remote_dep(version)
+    pattern = re.compile(
+        r"implementation\s+(?:project\(':ketchsdk'\)|'"
+        + re.escape(GROUP)
+        + r":"
+        + re.escape(ARTIFACT)
+        + r":[^']+')"
+    )
+    if not pattern.search(text):
+        raise SystemExit(f"Could not find ketchsdk dependency in {path}")
+
+    new_text, count = pattern.subn(target, text, count=1)
+    if count != 1:
+        raise SystemExit(f"Expected one ketchsdk dependency in {path}, replaced {count}")
+
+    if new_text == text:
+        print(f"Already {mode} in {path.name}")
+        return False
+
+    path.write_text(new_text, encoding="utf-8")
+    print(f"Updated {path.name} to {mode} ({target})")
+    return True
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit(f"Usage: {sys.argv[0]} <local|remote> <repo_root>")
+
+    mode = sys.argv[1]
+    if mode not in {"local", "remote"}:
+        raise SystemExit("mode must be local or remote")
+
+    repo_root = Path(sys.argv[2]).resolve()
+    version = os.environ.get("KETCH_ANDROID_SDK_VERSION", DEFAULT_VERSION)
+
+    changed = False
+    for rel in SAMPLE_GRADLE_FILES:
+        path = repo_root / rel
+        if not path.is_file():
+            raise SystemExit(f"Missing {path}")
+        if configure_file(path, mode, version):
+            changed = True
+
+    if not changed:
+        print(f"No changes needed (already {mode})")
+
+
+if __name__ == "__main__":
+    main()

--- a/.cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh
+++ b/.cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: run-sample-app.sh <compose|standard> [local] [--build-only] [--no-logs] [--full-system-logs]
+
+  compose|standard     Required. Which sample app module to build and launch.
+  (no local)           Use the published com.ketch.android:ketchsdk Maven artifact.
+  local                Use the in-repo :ketchsdk project (default for day-to-day SDK work).
+
+Options:
+  --build-only         Build and install the APK; do not launch or stream logs.
+  --no-logs            Alias for --build-only.
+  --full-system-logs   Stream unfiltered logcat for the sample process.
+
+Environment:
+  DEVICE_ID            adb device serial (default: first connected emulator/device).
+  AVD_NAME             Emulator AVD to boot when no device is connected.
+  KETCH_ANDROID_SDK_VERSION
+                        Pin remote Maven version (default: 3.0).
+
+Builds :sample-app-compose or :sample-app-standard, installs via adb, launches
+MainActivity, and streams filtered logcat (Ketch SDK + sample tags) unless --build-only.
+USAGE
+}
+
+if [[ $# -lt 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+SAMPLE_VARIANT="$1"
+shift
+
+case "$SAMPLE_VARIANT" in
+  compose|standard)
+    GRADLE_MODULE=":sample-app-${SAMPLE_VARIANT}"
+    PACKAGE_ID="com.ketch.android.sample.${SAMPLE_VARIANT}"
+    SAMPLE_TAG="KetchCompose"
+    if [[ "$SAMPLE_VARIANT" == "standard" ]]; then
+      SAMPLE_TAG="KetchSample"
+    fi
+    ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "First argument must be compose or standard, got: $SAMPLE_VARIANT" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+PACKAGE_MODE="remote"
+if [[ "${1:-}" == "local" ]]; then
+  PACKAGE_MODE="local"
+  shift
+fi
+
+build_only=0
+stream_logs=1
+full_system_logs=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --build-only|--no-logs)
+      build_only=1
+      stream_logs=0
+      shift
+      ;;
+    --full-system-logs)
+      full_system_logs=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_command adb
+require_command python3
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+GRADLEW="$REPO_ROOT/gradlew"
+APK_PATH="$REPO_ROOT/sample-app-${SAMPLE_VARIANT}/build/outputs/apk/debug/sample-app-${SAMPLE_VARIANT}-debug.apk"
+
+if [[ ! -x "$GRADLEW" ]]; then
+  echo "Gradle wrapper not found: $GRADLEW" >&2
+  exit 1
+fi
+
+python3 "$SCRIPT_DIR/configure-sample-dependency.py" "$PACKAGE_MODE" "$REPO_ROOT"
+
+adb_device_ready() {
+  adb devices 2>/dev/null | awk 'NR > 1 && $2 == "device" { print $1; exit }'
+}
+
+boot_emulator_if_needed() {
+  local serial
+  serial="$(adb_device_ready)"
+  if [[ -n "$serial" ]]; then
+    echo "$serial"
+    return
+  fi
+
+  if ! command -v emulator >/dev/null 2>&1; then
+    echo "No adb device connected and emulator command not on PATH." >&2
+    echo "Start an Android emulator in Android Studio, or connect a device." >&2
+    exit 1
+  fi
+
+  local avd="${AVD_NAME:-}"
+  if [[ -z "$avd" ]]; then
+    avd="$(emulator -list-avds 2>/dev/null | head -n 1 || true)"
+  fi
+  if [[ -z "$avd" ]]; then
+    echo "No AVD found. Create an emulator in Android Studio or set AVD_NAME." >&2
+    exit 1
+  fi
+
+  echo "No device connected. Booting emulator AVD: $avd"
+  emulator -avd "$avd" -no-snapshot-load >/dev/null 2>&1 &
+  adb wait-for-device
+  # Wait until boot completes
+  adb shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done' 2>/dev/null || sleep 15
+  adb_device_ready
+}
+
+DEVICE_ID="${DEVICE_ID:-}"
+if [[ -z "$DEVICE_ID" ]]; then
+  DEVICE_ID="$(boot_emulator_if_needed)"
+fi
+
+echo "Using device: $DEVICE_ID"
+adb -s "$DEVICE_ID" devices
+
+if [[ "$PACKAGE_MODE" == "local" ]]; then
+  echo "Building $GRADLE_MODULE using local :ketchsdk at $REPO_ROOT"
+else
+  echo "Building $GRADLE_MODULE using Maven com.ketch.android:ketchsdk (${KETCH_ANDROID_SDK_VERSION:-3.0})"
+fi
+
+(cd "$REPO_ROOT" && ./gradlew "${GRADLE_MODULE}:assembleDebug" --quiet)
+
+if [[ ! -f "$APK_PATH" ]]; then
+  echo "Built APK not found: $APK_PATH" >&2
+  exit 1
+fi
+
+echo "Installing $APK_PATH"
+adb -s "$DEVICE_ID" install -r "$APK_PATH" >/dev/null
+
+if [[ "$build_only" -eq 1 ]]; then
+  echo "Build/install complete (--build-only)."
+  exit 0
+fi
+
+echo "Launching $PACKAGE_ID/.MainActivity"
+adb -s "$DEVICE_ID" shell am force-stop "$PACKAGE_ID" >/dev/null 2>&1 || true
+adb -s "$DEVICE_ID" shell am start -n "$PACKAGE_ID/.MainActivity" >/dev/null
+
+log_stream_pid=""
+cleanup() {
+  if [[ -n "$log_stream_pid" ]] && kill -0 "$log_stream_pid" >/dev/null 2>&1; then
+    kill "$log_stream_pid" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+if [[ "$stream_logs" -eq 1 ]]; then
+  if [[ "$full_system_logs" -eq 1 ]]; then
+    echo "Streaming logcat for $PACKAGE_ID (full). Press Ctrl-C to stop."
+    adb -s "$DEVICE_ID" logcat --pid="$(adb -s "$DEVICE_ID" shell pidof -s "$PACKAGE_ID" 2>/dev/null || true)" &
+  else
+    echo "Streaming logcat (Ketch, $SAMPLE_TAG). Press Ctrl-C to stop."
+    adb -s "$DEVICE_ID" logcat -v brief Ketch:D "$SAMPLE_TAG":D '*:S' &
+  fi
+  log_stream_pid="$!"
+  wait "$log_stream_pid" || true
+else
+  echo "Sample launched. Dashboard is at the top of the app scroll view."
+fi


### PR DESCRIPTION
## Description of this change

Cursor skills and development-workflow rule documenting SDK Health Dashboard smoke flow (Load → Consent → ATT → Headless) with run scripts.

Independent PR off main (not stacked on SDK feature branches).

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

Docs/scripts only — verify run-sample-app.sh executes against sample app.

## Related issues

N/A — DX tooling.

## Checklist
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

## Review Notes

Pre-bot self-review on slice diff: no BLOCKER findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and local dev scripts only; no SDK or runtime behavior changes, aside from optional in-place Gradle dependency edits when running the configure script.
> 
> **Overview**
> Adds **Cursor DX tooling** so agents and developers can run Compose/standard Android samples and follow a consistent **SDK Health Dashboard** smoke path.
> 
> A new **`ketch-android-run-sample`** skill documents `/ketch-android-run-sample`, local vs Maven SDK wiring, emulator/`adb` options, and on-screen QA steps (Load → Consent → Headless; ATT called out as N/A on Android). **`run-sample-app.sh`** picks compose or standard, optionally flips dependencies via **`configure-sample-dependency.py`**, boots an emulator if needed, builds/installs, launches `MainActivity`, and streams filtered logcat. An always-on **`development-workflow.mdc`** rule ties together Gradle commands, dashboard sections, `webResourceUrlOverrides` notes, and a pre-merge validation checklist.
> 
> **Note:** Remote mode mutates `sample-app-*/build.gradle` on disk when switching between `project(':ketchsdk')` and Maven coordinates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e213b1ac3e500b25acbc1a5e6ab94d6de76c64b5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->