### PR TITLE
chore: vulns

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,55 @@ buildscript {
             'dokka'       : '1.9.20',
             'junit'       : '4.13.2',
             'gson'        : '2.13.2',
-            'webkit'      : '1.15.0'
+            'webkit'      : '1.15.0',
+            // Patched versions for transitive build-tooling CVEs (AGP, Dokka, bundletool, jetifier).
+            'jackson'     : '2.15.3',
+            'netty'       : '4.1.133.Final',
+            'protobuf'    : '3.25.5',
+            'jose4j'      : '0.9.6',
+            'jdom2'       : '2.0.6.1',
+    ]
+    ext.applyTransitiveSecurityOverrides = { details, versions ->
+        switch (details.requested.group) {
+            case 'io.netty':
+                details.useVersion(versions.netty)
+                details.because('Netty < 4.1.133.Final has known CVEs (transitive via AGP/grpc)')
+                break
+            case { it.startsWith('com.fasterxml.jackson') }:
+                details.useVersion(versions.jackson)
+                details.because('Jackson < 2.15.0 has known CVEs (transitive via Dokka)')
+                break
+            case 'com.google.protobuf':
+                details.useVersion(versions.protobuf)
+                details.because('protobuf < 3.25.5 has known CVEs (transitive via AGP)')
+                break
+            case 'org.bitbucket.b_c':
+                if (details.requested.name == 'jose4j') {
+                    details.useVersion(versions.jose4j)
+                    details.because('jose4j < 0.9.6 has known CVEs (transitive via bundletool)')
+                }
+                break
+            case 'org.jdom':
+                if (details.requested.name == 'jdom2') {
+                    details.useVersion(versions.jdom2)
+                    details.because('jdom2 < 2.0.6.1 has known CVEs (transitive via jetifier)')
+                }
+                break
+        }
+    }
+    ext.securityForcedArtifacts = [
+            'com.google.protobuf:protobuf-kotlin:3.25.5',
+            'io.netty:netty-buffer:4.1.133.Final',
+            'io.netty:netty-codec:4.1.133.Final',
+            'io.netty:netty-codec-http:4.1.133.Final',
+            'io.netty:netty-codec-http2:4.1.133.Final',
+            'io.netty:netty-codec-socks:4.1.133.Final',
+            'io.netty:netty-common:4.1.133.Final',
+            'io.netty:netty-handler:4.1.133.Final',
+            'io.netty:netty-handler-proxy:4.1.133.Final',
+            'io.netty:netty-resolver:4.1.133.Final',
+            'io.netty:netty-transport:4.1.133.Final',
+            'io.netty:netty-transport-native-unix-common:4.1.133.Final',
     ]
     repositories {
         google()
@@ -37,6 +85,15 @@ buildscript {
         classpath "org.jetbrains.kotlin:compose-compiler-gradle-plugin:${versions.kotlin}"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}"
     }
+
+    configurations.classpath {
+        resolutionStrategy {
+            eachDependency { details ->
+                applyTransitiveSecurityOverrides(details, versions)
+            }
+            force(securityForcedArtifacts as Object[])
+        }
+    }
 }
 
 allprojects {
@@ -47,6 +104,15 @@ allprojects {
         maven { url 'https://jitpack.io' }
         maven { url "https://dl.cloudsmith.io/public/indooratlas/mvn-public/maven" }
         maven { url "https://software.mobile.pendo.io/artifactory/android-release" }
+    }
+
+    configurations.configureEach {
+        resolutionStrategy {
+            eachDependency { details ->
+                rootProject.ext.applyTransitiveSecurityOverrides(details, rootProject.ext.versions)
+            }
+            force(rootProject.ext.securityForcedArtifacts as Object[])
+        }
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> address vulnerabilities

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time dependency resolution only; no app runtime or business logic changes, though forced versions could affect Gradle/AGP compatibility if upstream APIs diverge.
> 
> **Overview**
> Adds **Gradle dependency resolution overrides** in the root `build.gradle` so vulnerable **transitive build-tooling** libraries are upgraded without bumping AGP, Dokka, bundletool, or jetifier directly.
> 
> Centralizes patched version constants (Jackson, Netty, protobuf, jose4j, jdom2) and an `applyTransitiveSecurityOverrides` helper, then applies it on **`buildscript` classpath** and **all project configurations** via `eachDependency` plus explicit **`force`** on key Netty modules and `protobuf-kotlin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0755310974e27eec810a99dc3a23295ca2aae1ff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->