### PR TITLE
sample app

### DIFF
--- a/.cursor/rules/development-workflow.mdc
+++ b/.cursor/rules/development-workflow.mdc
@@ -27,6 +27,11 @@ alwaysApply: true
 | `./gradlew dokkaHtmlMultiModule` | Generate API docs |
 | `./run-integration-tests.sh` | Clean build + full instrumented run (checks for a connected device) |
 
+`scripts/run-sample.sh` (via the `make run-*` targets above) always builds the samples against the
+local `:ketchsdk` project. To additionally test against a **published** `com.ketch.android:ketchsdk`
+Maven artifact (e.g. verifying a release), use the `/ketch-android-run-sample` skill instead —
+see `.cursor/skills/ketch-android-run-sample/SKILL.md`.
+
 ## Validation Checklist
 
 Run before considering any change complete:

--- a/.cursor/skills/ketch-android-run-sample/SKILL.md
+++ b/.cursor/skills/ketch-android-run-sample/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: ketch-android-run-sample
+description: Configures the in-repo Android sample apps (Compose or standard) for either the published com.ketch.android:ketchsdk Maven artifact or the local :ketchsdk module, boots an emulator when needed, builds, installs, launches, and streams filtered logcat. Use when the user runs /ketch-android-run-sample or wants manual sample-app QA on Android.
+---
+
+# ketch-android-run-sample
+
+## Instructions
+
+When the user invokes **`/ketch-android-run-sample`** (or asks to run the Android sample with production / local SDK):
+
+1. `cd` to the `ketch-android` repository root.
+
+2. Run the helper script with a **required** sample variant:
+
+**Local SDK (default for SDK development)** — sample `build.gradle` uses `project(':ketchsdk')`:
+
+```bash
+bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh compose local
+bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh standard local
+```
+
+**Published Maven artifact** — sample depends on `com.ketch.android:ketchsdk` (version from `KETCH_ANDROID_SDK_VERSION` or `3.0`):
+
+```bash
+bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh compose
+bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh standard
+```
+
+The script boots an emulator when no `adb` device is connected, runs `./gradlew :sample-app-*:assembleDebug`, installs the APK, launches `MainActivity`, and streams filtered logcat (`Ketch`, sample tag). Stop with `Ctrl-C`.
+
+For plain local-source runs (no Maven toggle needed), `scripts/run-sample.sh` at the repo root
+(or `make run-standard` / `make run-compose` / `make run-integration-test-app`) is the simpler,
+non-agent entry point — see `.cursor/rules/development-workflow.mdc`.
+
+## Manual testing basics
+
+**Needs:** Android Studio or SDK, emulator or USB device, `adb` on PATH, network for CDN.
+
+**Launch:** `bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh compose local` from the `ketch-android` repo root.
+
+**In the app:** the **Info** section is at the top of the scroll view — org `ketch_samples`, property `android`, environment `production`, language `en`, plus live Jurisdiction/Region populated after `Load`.
+
+**Smoke flow:** **Load** (Actions) → Jurisdiction/Region populate in Info → **Consent** (Actions cards row) shows the consent banner → **Preferences** opens the Privacy Center honoring the checked tabs / initial tab from Preference Options.
+
+## Other options
+
+```bash
+DEVICE_ID=emulator-5554 bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh compose local
+AVD_NAME="Pixel_7_API_34" bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh standard local
+KETCH_ANDROID_SDK_VERSION=3.0 bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh compose
+bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh compose local --build-only
+bash .cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh standard local --full-system-logs
+```
+
+## Manual QA checklist
+
+Verify on-screen panels (no logcat required):
+
+1. **Info** — Org Code/Property/Environment/Language show `ketch_samples`/`android`/`production`/`en`.
+2. **Preference Options** — toggling allowed-tab checkboxes and the initial-tab radio changes what
+   **Preferences** opens to.
+3. **Actions** — **Load** (Info's Jurisdiction/Region populate from callbacks), **Consent** (banner
+   shows), **Preferences** (Privacy Center honors tab selection), **Reload**, **Apply CSS**.
+4. **Privacy Strings** — **Log Values** dumps IAB TCF/US-Privacy/GPP strings persisted by the SDK.
+5. **Event Log** — timestamped callback trace (jurisdiction/region/consent/error/etc).
+
+## Notes
+
+- `integration-tests` is the Espresso automation host; use **compose** or **standard** samples for
+  manual QA.
+- Remote mode needs the pinned Maven artifact to be resolvable from your configured repositories.
+- To point the SDK's tag script at a local dev server instead of the CDN, flip
+  `DevUrlOverrides.ENABLED` in the sample's `DevUrlOverrides.kt`.

--- a/.cursor/skills/ketch-android-run-sample/scripts/configure-sample-dependency.py
+++ b/.cursor/skills/ketch-android-run-sample/scripts/configure-sample-dependency.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Switch sample apps between the local :ketchsdk project and a published Maven artifact."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+GROUP = "com.ketch.android"
+ARTIFACT = "ketchsdk"
+DEFAULT_VERSION = "3.0"
+
+SAMPLE_GRADLE_FILES = (
+    "sample-app-compose/build.gradle",
+    "sample-app-standard/build.gradle",
+)
+
+LOCAL_DEP = "implementation project(':ketchsdk')"
+REMOTE_DEP_TEMPLATE = "implementation '{group}:{artifact}:{version}'"
+
+
+def remote_dep(version: str) -> str:
+    return REMOTE_DEP_TEMPLATE.format(group=GROUP, artifact=ARTIFACT, version=version)
+
+
+def configure_file(path: Path, mode: str, version: str) -> bool:
+    text = path.read_text(encoding="utf-8")
+    target = LOCAL_DEP if mode == "local" else remote_dep(version)
+    pattern = re.compile(
+        r"implementation\s+(?:project\(':ketchsdk'\)|'"
+        + re.escape(GROUP)
+        + r":"
+        + re.escape(ARTIFACT)
+        + r":[^']+')"
+    )
+    if not pattern.search(text):
+        raise SystemExit(f"Could not find ketchsdk dependency in {path}")
+
+    new_text, count = pattern.subn(target, text, count=1)
+    if count != 1:
+        raise SystemExit(f"Expected one ketchsdk dependency in {path}, replaced {count}")
+
+    if new_text == text:
+        print(f"Already {mode} in {path.name}")
+        return False
+
+    path.write_text(new_text, encoding="utf-8")
+    print(f"Updated {path.name} to {mode} ({target})")
+    return True
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit(f"Usage: {sys.argv[0]} <local|remote> <repo_root>")
+
+    mode = sys.argv[1]
+    if mode not in {"local", "remote"}:
+        raise SystemExit("mode must be local or remote")
+
+    repo_root = Path(sys.argv[2]).resolve()
+    version = os.environ.get("KETCH_ANDROID_SDK_VERSION", DEFAULT_VERSION)
+
+    changed = False
+    for rel in SAMPLE_GRADLE_FILES:
+        path = repo_root / rel
+        if not path.is_file():
+            raise SystemExit(f"Missing {path}")
+        if configure_file(path, mode, version):
+            changed = True
+
+    if not changed:
+        print(f"No changes needed (already {mode})")
+
+
+if __name__ == "__main__":
+    main()

--- a/.cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh
+++ b/.cursor/skills/ketch-android-run-sample/scripts/run-sample-app.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: run-sample-app.sh <compose|standard> [local] [--build-only] [--no-logs] [--full-system-logs]
+
+  compose|standard     Required. Which sample app module to build and launch.
+  (no local)           Use the published com.ketch.android:ketchsdk Maven artifact.
+  local                Use the in-repo :ketchsdk project (default for day-to-day SDK work).
+
+Options:
+  --build-only         Build and install the APK; do not launch or stream logs.
+  --no-logs            Alias for --build-only.
+  --full-system-logs   Stream unfiltered logcat for the sample process.
+
+Environment:
+  DEVICE_ID            adb device serial (default: first connected emulator/device).
+  AVD_NAME             Emulator AVD to boot when no device is connected.
+  KETCH_ANDROID_SDK_VERSION
+                        Pin remote Maven version (default: 3.0).
+
+Builds :sample-app-compose or :sample-app-standard, installs via adb, launches
+MainActivity, and streams filtered logcat (Ketch SDK + sample tags) unless --build-only.
+
+For the plain local-source case (no Maven toggle needed), scripts/run-sample.sh at the
+repo root (or `make run-standard` / `make run-compose` / `make run-integration-test-app`)
+is the simpler entry point.
+USAGE
+}
+
+if [[ $# -lt 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+SAMPLE_VARIANT="$1"
+shift
+
+case "$SAMPLE_VARIANT" in
+  compose|standard)
+    GRADLE_MODULE=":sample-app-${SAMPLE_VARIANT}"
+    PACKAGE_ID="com.ketch.android.sample.${SAMPLE_VARIANT}"
+    SAMPLE_TAG="KetchCompose"
+    if [[ "$SAMPLE_VARIANT" == "standard" ]]; then
+      SAMPLE_TAG="KetchSample"
+    fi
+    ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "First argument must be compose or standard, got: $SAMPLE_VARIANT" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+PACKAGE_MODE="remote"
+if [[ "${1:-}" == "local" ]]; then
+  PACKAGE_MODE="local"
+  shift
+fi
+
+build_only=0
+stream_logs=1
+full_system_logs=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --build-only|--no-logs)
+      build_only=1
+      stream_logs=0
+      shift
+      ;;
+    --full-system-logs)
+      full_system_logs=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_command adb
+require_command python3
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+GRADLEW="$REPO_ROOT/gradlew"
+APK_PATH="$REPO_ROOT/sample-app-${SAMPLE_VARIANT}/build/outputs/apk/debug/sample-app-${SAMPLE_VARIANT}-debug.apk"
+
+if [[ ! -x "$GRADLEW" ]]; then
+  echo "Gradle wrapper not found: $GRADLEW" >&2
+  exit 1
+fi
+
+python3 "$SCRIPT_DIR/configure-sample-dependency.py" "$PACKAGE_MODE" "$REPO_ROOT"
+
+adb_device_ready() {
+  adb devices 2>/dev/null | awk 'NR > 1 && $2 == "device" { print $1; exit }'
+}
+
+boot_emulator_if_needed() {
+  local serial
+  serial="$(adb_device_ready)"
+  if [[ -n "$serial" ]]; then
+    echo "$serial"
+    return
+  fi
+
+  if ! command -v emulator >/dev/null 2>&1; then
+    echo "No adb device connected and emulator command not on PATH." >&2
+    echo "Start an Android emulator in Android Studio, or connect a device." >&2
+    exit 1
+  fi
+
+  local avd="${AVD_NAME:-}"
+  if [[ -z "$avd" ]]; then
+    avd="$(emulator -list-avds 2>/dev/null | head -n 1 || true)"
+  fi
+  if [[ -z "$avd" ]]; then
+    echo "No AVD found. Create an emulator in Android Studio or set AVD_NAME." >&2
+    exit 1
+  fi
+
+  echo "No device connected. Booting emulator AVD: $avd"
+  emulator -avd "$avd" -no-snapshot-load >/dev/null 2>&1 &
+  adb wait-for-device
+  # Wait until boot completes
+  adb shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done' 2>/dev/null || sleep 15
+  adb_device_ready
+}
+
+DEVICE_ID="${DEVICE_ID:-}"
+if [[ -z "$DEVICE_ID" ]]; then
+  DEVICE_ID="$(boot_emulator_if_needed)"
+fi
+
+echo "Using device: $DEVICE_ID"
+adb -s "$DEVICE_ID" devices
+
+if [[ "$PACKAGE_MODE" == "local" ]]; then
+  echo "Building $GRADLE_MODULE using local :ketchsdk at $REPO_ROOT"
+else
+  echo "Building $GRADLE_MODULE using Maven com.ketch.android:ketchsdk (${KETCH_ANDROID_SDK_VERSION:-3.0})"
+fi
+
+(cd "$REPO_ROOT" && ./gradlew "${GRADLE_MODULE}:assembleDebug" --quiet)
+
+if [[ ! -f "$APK_PATH" ]]; then
+  echo "Built APK not found: $APK_PATH" >&2
+  exit 1
+fi
+
+echo "Installing $APK_PATH"
+adb -s "$DEVICE_ID" install -r "$APK_PATH" >/dev/null
+
+if [[ "$build_only" -eq 1 ]]; then
+  echo "Build/install complete (--build-only)."
+  exit 0
+fi
+
+echo "Launching $PACKAGE_ID/.MainActivity"
+adb -s "$DEVICE_ID" shell am force-stop "$PACKAGE_ID" >/dev/null 2>&1 || true
+adb -s "$DEVICE_ID" shell am start -n "$PACKAGE_ID/.MainActivity" >/dev/null
+
+log_stream_pid=""
+cleanup() {
+  if [[ -n "$log_stream_pid" ]] && kill -0 "$log_stream_pid" >/dev/null 2>&1; then
+    kill "$log_stream_pid" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+if [[ "$stream_logs" -eq 1 ]]; then
+  if [[ "$full_system_logs" -eq 1 ]]; then
+    echo "Streaming logcat for $PACKAGE_ID (full). Press Ctrl-C to stop."
+    adb -s "$DEVICE_ID" logcat --pid="$(adb -s "$DEVICE_ID" shell pidof -s "$PACKAGE_ID" 2>/dev/null || true)" &
+  else
+    echo "Streaming logcat (Ketch, $SAMPLE_TAG). Press Ctrl-C to stop."
+    adb -s "$DEVICE_ID" logcat -v brief Ketch:D "$SAMPLE_TAG":D '*:S' &
+  fi
+  log_stream_pid="$!"
+  wait "$log_stream_pid" || true
+else
+  echo "Sample launched. Info panel is at the top of the app scroll view."
+fi

--- a/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
@@ -30,7 +30,8 @@ class Ketch private constructor(
     private val environment: String?,
     private val listener: Listener?,
     private val ketchUrl: String?,
-    private val logLevel: LogLevel
+    private val logLevel: LogLevel,
+    private var webResourceUrlOverrides: Map<String, String> = emptyMap(),
 ) {
     // Use application context for non-UI operations to avoid memory leaks
     private val context: Context = context.applicationContext
@@ -157,7 +158,8 @@ class Ketch private constructor(
             ageUpper,
             bottomPadding,
             topPadding,
-            cssStyle
+            cssStyle,
+            webResourceUrlOverrides,
         )
         return true
     }
@@ -204,7 +206,8 @@ class Ketch private constructor(
             ageUpper,
             bottomPadding,
             topPadding,
-            cssStyle
+            cssStyle,
+            webResourceUrlOverrides,
         )
         return true
     }
@@ -251,7 +254,8 @@ class Ketch private constructor(
             ageUpper,
             bottomPadding,
             topPadding,
-            cssStyle
+            cssStyle,
+            webResourceUrlOverrides,
         )
         return true
     }
@@ -302,7 +306,8 @@ class Ketch private constructor(
             ageUpper,
             bottomPadding,
             topPadding,
-            cssStyle
+            cssStyle,
+            webResourceUrlOverrides,
         )
         return true
     }
@@ -371,6 +376,16 @@ class Ketch private constructor(
      */
     fun setCssStyle(cssStyle: String?) {
         this.cssStyle = validateCssStyle(cssStyle)
+    }
+
+    /**
+     * Redirect exact-match WebView resource URLs (e.g. dev/staging tag scripts) to local dev servers.
+     *
+     * @param overrides: map of source URL/path/filename pattern to destination URL
+     */
+    fun setWebResourceUrlOverrides(overrides: Map<String, String>) {
+        webResourceUrlOverrides = overrides.toMap()
+        activeWebView?.setWebResourceUrlOverrides(webResourceUrlOverrides)
     }
 
     /**
@@ -654,6 +669,7 @@ class Ketch private constructor(
             // foreground Activity is tracked (callbacks still resolve; display needs a host).
             val webViewContext = resolveWebViewContext()
             val webView = KetchWebView(webViewContext, shouldRetry)
+            webView.setWebResourceUrlOverrides(webResourceUrlOverrides)
 
             // Enable debug mode
             if (logLevel === LogLevel.DEBUG) {
@@ -975,6 +991,7 @@ class Ketch private constructor(
             listener: Listener?,
             ketchUrl: String?,
             logLevel: LogLevel,
+            webResourceUrlOverrides: Map<String, String> = emptyMap(),
         ) = Ketch(
             context = context,
             seedActivity = context as? FragmentActivity,
@@ -985,6 +1002,7 @@ class Ketch private constructor(
             listener = listener,
             ketchUrl = ketchUrl,
             logLevel = logLevel,
+            webResourceUrlOverrides = webResourceUrlOverrides,
         )
 
         fun create(
@@ -996,6 +1014,7 @@ class Ketch private constructor(
             listener: Listener?,
             ketchUrl: String?,
             logLevel: LogLevel,
+            webResourceUrlOverrides: Map<String, String> = emptyMap(),
         ) = Ketch(
             context = context,
             seedActivity = context as? FragmentActivity,
@@ -1006,6 +1025,7 @@ class Ketch private constructor(
             listener = listener,
             ketchUrl = ketchUrl,
             logLevel = logLevel,
+            webResourceUrlOverrides = webResourceUrlOverrides,
         )
     }
 }

--- a/ketchsdk/src/main/java/com/ketch/android/KetchSdk.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/KetchSdk.kt
@@ -28,6 +28,8 @@ object KetchSdk {
      * @param listener - Ketch.Listener. Optional
      * @param ketchUrl - Overrides the ketch url. Optional
      * @param logLevel - the log level, can be TRACE, DEBUG, INFO, WARN, ERROR. Default is ERROR
+     * @param webResourceUrlOverrides - redirects exact-match WebView resource URLs (e.g. dev/staging
+     *   tag scripts) to local dev servers. Optional
      */
     fun create(
         context: Context,
@@ -36,7 +38,8 @@ object KetchSdk {
         environment: String? = null,
         listener: Ketch.Listener? = null,
         ketchUrl: String? = null,
-        logLevel: Ketch.LogLevel = Ketch.LogLevel.ERROR
+        logLevel: Ketch.LogLevel = Ketch.LogLevel.ERROR,
+        webResourceUrlOverrides: Map<String, String> = emptyMap(),
     ): Ketch {
         return Ketch.create(
             context = context,
@@ -46,6 +49,7 @@ object KetchSdk {
             listener = listener,
             ketchUrl = ketchUrl,
             logLevel = logLevel,
+            webResourceUrlOverrides = webResourceUrlOverrides,
         )
     }
 
@@ -77,7 +81,8 @@ object KetchSdk {
         environment: String? = null,
         listener: Ketch.Listener? = null,
         ketchUrl: String? = null,
-        logLevel: Ketch.LogLevel = Ketch.LogLevel.ERROR
+        logLevel: Ketch.LogLevel = Ketch.LogLevel.ERROR,
+        webResourceUrlOverrides: Map<String, String> = emptyMap(),
     ): Ketch {
         return Ketch.create(
             context = context,
@@ -87,7 +92,8 @@ object KetchSdk {
             environment = environment,
             listener = listener,
             ketchUrl = ketchUrl,
-            logLevel = logLevel
+            logLevel = logLevel,
+            webResourceUrlOverrides = webResourceUrlOverrides,
         )
     }
 }

--- a/ketchsdk/src/main/java/com/ketch/android/api/KetchDataCenter.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/api/KetchDataCenter.kt
@@ -1,0 +1,10 @@
+package com.ketch.android.api
+
+/**
+ * Ketch CDN region for WebView API calls (matches Flutter / React Native / iOS maps).
+ */
+enum class KetchDataCenter(val baseUrl: String) {
+    US("https://global.ketchcdn.com/web/v3"),
+    EU("https://eu.ketchcdn.com/web/v3"),
+    UAT("https://dev.ketchcdn.com/web/v3"),
+}

--- a/ketchsdk/src/main/java/com/ketch/android/data/Index.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/data/Index.kt
@@ -1,5 +1,7 @@
 package com.ketch.android.data
 
+import com.google.gson.Gson
+
 /*
 * https://global.ketchcdn.com/web/v3//config/ketch_samples/android/boot.js?ketch_log=DEBUG
 *       &ketch_lang=en&ketch_jurisdiction=default&ketch_region=US
@@ -23,7 +25,8 @@ fun getIndexHtml(
     ageUpper: Int? = null,
     bottomPadding: String = "0px",
     topPadding: String = "0px",
-    cssStyleOverride: String? = null
+    cssStyleOverride: String? = null,
+    webResourceUrlOverrides: Map<String, String> = emptyMap(),
 ) =
     "<html>\n" +
             "  <head>\n" +
@@ -128,6 +131,7 @@ fun getIndexHtml(
             "        };\n" +
             "      })(window.console);\n" +
             "\n" +
+            webResourceUrlOverridesScript(webResourceUrlOverrides) +
             "      function initKetchTag(parameters) {\n" +
             "        console.log('Ketch Tag is initialization started...');\n" +
             "        // Use parameters to set SDK query params here\n" +
@@ -204,3 +208,61 @@ fun getIndexHtml(
             "    </script>\n" +
             "  </body>\n" +
             "</html>"
+
+private fun webResourceUrlOverridesScript(overrides: Map<String, String>): String {
+    if (overrides.isEmpty()) return ""
+    val overridesJson = Gson().toJson(overrides)
+    return webResourceUrlOverridesInstallScriptBody() +
+        "\n      installWebResourceUrlOverrides($overridesJson);\n"
+}
+
+private fun webResourceUrlOverridesInstallScriptBody(): String =
+    """
+        function installWebResourceUrlOverrides(overrides) {
+          if (!overrides || !Object.keys(overrides).length) return;
+          function resolveUrl(url) {
+            if (!url) return url;
+            if (overrides[url]) return overrides[url];
+            var base = url.split('?')[0].split('#')[0];
+            if (base !== url && overrides[base]) return overrides[base];
+            for (var key in overrides) {
+              if (!Object.prototype.hasOwnProperty.call(overrides, key)) continue;
+              if (key === url || key === base) continue;
+              if (key.charAt(0) === '/' && base.indexOf(key) !== -1) return overrides[key];
+              if (key.indexOf('://') !== -1) continue;
+              if (base.endsWith(key) || base.indexOf('/' + key) !== -1) return overrides[key];
+            }
+            return url;
+          }
+          var srcDesc = Object.getOwnPropertyDescriptor(HTMLScriptElement.prototype, 'src');
+          if (srcDesc && srcDesc.set) {
+            var nativeSrcSet = srcDesc.set;
+            var nativeSrcGet = srcDesc.get;
+            Object.defineProperty(HTMLScriptElement.prototype, 'src', {
+              set: function (value) { nativeSrcSet.call(this, resolveUrl(value)); },
+              get: nativeSrcGet,
+              configurable: true,
+            });
+          }
+          var origSetAttribute = Element.prototype.setAttribute;
+          Element.prototype.setAttribute = function (name, value) {
+            if (name === 'src' && this.tagName === 'SCRIPT') {
+              return origSetAttribute.call(this, name, resolveUrl(value));
+            }
+            return origSetAttribute.call(this, name, value);
+          };
+          if (window.fetch) {
+            var origFetch = window.fetch.bind(window);
+            window.fetch = function (input, init) {
+              if (typeof input === 'string') {
+                var mapped = resolveUrl(input);
+                if (mapped !== input) input = mapped;
+              } else if (input && input.url) {
+                var mappedUrl = resolveUrl(input.url);
+                if (mappedUrl !== input.url) input = new Request(mappedUrl, input);
+              }
+              return origFetch(input, init);
+            };
+          }
+        }
+    """.trimIndent() + "\n"

--- a/ketchsdk/src/main/java/com/ketch/android/ui/KetchWebView.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/ui/KetchWebView.kt
@@ -47,6 +47,13 @@ class KetchWebView(context: Context, shouldRetry: Boolean = false) : WebView(con
 
     var listener: WebViewListener? = null
     private val localContentWebViewClient = LocalContentWebViewClient(shouldRetry)
+    private var webResourceUrlOverrides: Map<String, String> = emptyMap()
+
+    /** Redirect exact-match WebView resource URLs (e.g. dev/staging tag scripts) to local dev servers. */
+    fun setWebResourceUrlOverrides(overrides: Map<String, String>) {
+        webResourceUrlOverrides = overrides
+        localContentWebViewClient.webResourceUrlOverrides = overrides
+    }
 
     init {
         setBackgroundColor(Color.TRANSPARENT)
@@ -121,6 +128,8 @@ class KetchWebView(context: Context, shouldRetry: Boolean = false) : WebView(con
 
     class LocalContentWebViewClient(private var shouldRetry: Boolean = false) : WebViewClientCompat() {
 
+        var webResourceUrlOverrides: Map<String, String> = emptyMap()
+
         // Flag indicating if the webview has finished loading
         // We use atomic boolean here because we are using it within a coroutine
         private var isLoaded = AtomicBoolean(false)
@@ -138,6 +147,14 @@ class KetchWebView(context: Context, shouldRetry: Boolean = false) : WebView(con
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             view.context.startActivity(intent)
             return true
+        }
+
+        override fun shouldInterceptRequest(
+            view: WebView,
+            request: WebResourceRequest,
+        ): WebResourceResponse? {
+            WebResourceOverrideHandler.intercept(webResourceUrlOverrides, request)?.let { return it }
+            return super.shouldInterceptRequest(view, request)
         }
 
         override fun onLoadResource(view: WebView?, url: String?) {
@@ -246,8 +263,10 @@ class KetchWebView(context: Context, shouldRetry: Boolean = false) : WebView(con
         ageUpper: Int?,
         bottomPadding: Int?,
         topPadding: Int?,
-        cssStyle: String?
+        cssStyle: String?,
+        webResourceUrlOverrides: Map<String, String> = emptyMap(),
     ) {
+        setWebResourceUrlOverrides(webResourceUrlOverrides)
         clearCache(true)
 
         // Convert padding values to string
@@ -280,7 +299,8 @@ class KetchWebView(context: Context, shouldRetry: Boolean = false) : WebView(con
             ageUpper = ageUpper,
             bottomPadding = bottomPaddingPx,
             topPadding = topPaddingPx,
-            cssStyleOverride = cssStyle
+            cssStyleOverride = cssStyle,
+            webResourceUrlOverrides = webResourceUrlOverrides,
         )
 
         loadDataWithBaseURL("http://localhost", indexHtml, "text/html", "UTF-8", null)

--- a/ketchsdk/src/main/java/com/ketch/android/ui/WebResourceOverrideHandler.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/ui/WebResourceOverrideHandler.kt
@@ -1,0 +1,62 @@
+package com.ketch.android.ui
+
+import android.util.Log
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * Redirects exact-match WebView resource URLs (e.g. UAT tag scripts) to local dev servers.
+ */
+internal object WebResourceOverrideHandler {
+    private const val TAG = "KetchWebOverride"
+
+    fun intercept(
+        overrides: Map<String, String>,
+        request: WebResourceRequest?,
+    ): WebResourceResponse? {
+        if (overrides.isEmpty() || request == null) return null
+        val sourceUrl = request.url?.toString() ?: return null
+        val destinationUrl = WebResourceUrlOverrideResolver.resolve(sourceUrl, overrides) ?: return null
+        return loadResponse(sourceUrl, destinationUrl)
+    }
+
+    private fun loadResponse(sourceUrl: String, destinationUrl: String): WebResourceResponse? {
+        var connection: HttpURLConnection? = null
+        return try {
+            connection = URL(destinationUrl).openConnection() as HttpURLConnection
+            when (val responseCode = connection.responseCode) {
+                in 200..299 -> {
+                    Log.d(TAG, "Redirected $sourceUrl -> $destinationUrl")
+                    WebResourceResponse(
+                        mimeTypeFor(destinationUrl),
+                        connection.contentEncoding ?: "UTF-8",
+                        connection.inputStream,
+                    )
+                }
+                else -> {
+                    Log.e(
+                        TAG,
+                        "Override destination HTTP $responseCode for $sourceUrl -> $destinationUrl",
+                    )
+                    connection.errorStream?.close()
+                    connection.disconnect()
+                    connection = null
+                    null
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed override $sourceUrl -> $destinationUrl: ${e.message}", e)
+            connection?.disconnect()
+            null
+        }
+    }
+
+    private fun mimeTypeFor(url: String): String = when {
+        url.endsWith(".js", ignoreCase = true) -> "application/javascript"
+        url.endsWith(".json", ignoreCase = true) -> "application/json"
+        url.endsWith(".css", ignoreCase = true) -> "text/css"
+        else -> "text/plain"
+    }
+}

--- a/ketchsdk/src/main/java/com/ketch/android/ui/WebResourceUrlOverrideResolver.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/ui/WebResourceUrlOverrideResolver.kt
@@ -1,0 +1,32 @@
+package com.ketch.android.ui
+
+/**
+ * Resolves a WebView resource URL against override rules.
+ *
+ * Keys may be:
+ * - Exact URL (with or without query string)
+ * - Path fragment (starts with `/`, matched via [String.contains])
+ * - Filename suffix (e.g. `ketch-sdk.js`, matched via path ending)
+ */
+internal object WebResourceUrlOverrideResolver {
+    fun resolve(sourceUrl: String, overrides: Map<String, String>): String? {
+        if (overrides.isEmpty() || sourceUrl.isBlank()) return null
+
+        overrides[sourceUrl]?.let { return it }
+
+        val base = sourceUrl.substringBefore('#').substringBefore('?')
+        if (base != sourceUrl) {
+            overrides[base]?.let { return it }
+        }
+
+        for ((pattern, destination) in overrides) {
+            if (pattern == sourceUrl || pattern == base) continue
+            when {
+                pattern.startsWith("/") && base.contains(pattern) -> return destination
+                pattern.contains("://") -> Unit
+                base.endsWith(pattern) || base.contains("/$pattern") -> return destination
+            }
+        }
+        return null
+    }
+}

--- a/sample-app-compose/src/main/java/com/ketch/android/sample/compose/ComposeSampleApplication.kt
+++ b/sample-app-compose/src/main/java/com/ketch/android/sample/compose/ComposeSampleApplication.kt
@@ -14,20 +14,24 @@ class ComposeSampleApplication : Application() {
     lateinit var ketch: Ketch
         private set
 
+    val infoState = SampleInfoState()
+
     var logCallback: ((String) -> Unit)? = null
 
     override fun onCreate() {
         super.onCreate()
         ketch = KetchSdk.create(
             context = this,
-            organization = ORG_CODE,
-            property = PROPERTY,
-            environment = ENVIRONMENT,
+            organization = SampleConfig.ORG_CODE,
+            property = SampleConfig.PROPERTY,
+            environment = SampleConfig.ENVIRONMENT,
             listener = sharedListener,
-            ketchUrl = null,
+            ketchUrl = SampleConfig.dataCenter.baseUrl,
             logLevel = Ketch.LogLevel.DEBUG,
+            webResourceUrlOverrides = if (DevUrlOverrides.ENABLED) DevUrlOverrides.forEmulator else emptyMap(),
         )
-        ketch.setIdentities(mapOf("aaid" to "sample-test-123"))
+        ketch.setLanguage(SampleConfig.LANGUAGE)
+        ketch.setIdentities(SampleConfig.identities)
     }
 
     private val sharedListener = object : Ketch.Listener {
@@ -54,11 +58,13 @@ class ComposeSampleApplication : Application() {
         override fun onRegionInfoUpdated(regionInfo: String?) {
             Log.d(TAG, "onRegionInfoUpdated: $regionInfo")
             log("onRegionInfoUpdated: $regionInfo")
+            infoState.updateRegion(regionInfo)
         }
 
         override fun onJurisdictionUpdated(jurisdiction: String?) {
             Log.d(TAG, "onJurisdictionUpdated: $jurisdiction")
             log("onJurisdictionUpdated: $jurisdiction")
+            infoState.updateJurisdiction(jurisdiction)
         }
 
         override fun onIdentitiesUpdated(identities: String?) {
@@ -67,8 +73,9 @@ class ComposeSampleApplication : Application() {
         }
 
         override fun onConsentUpdated(consent: Consent) {
-            Log.d(TAG, "onConsentUpdated: purposes=${consent.purposes}")
-            log("onConsentUpdated: ${consent.purposes}")
+            val summary = formatConsent(consent)
+            Log.d(TAG, "onConsentUpdated: $summary")
+            log("onConsentUpdated: $summary")
         }
 
         override fun onError(errMsg: String?) {
@@ -108,8 +115,5 @@ class ComposeSampleApplication : Application() {
 
     companion object {
         private const val TAG = "KetchCompose"
-        const val ORG_CODE = "ketch_samples"
-        const val PROPERTY = "android"
-        const val ENVIRONMENT = "production"
     }
 }

--- a/sample-app-compose/src/main/java/com/ketch/android/sample/compose/DevUrlOverrides.kt
+++ b/sample-app-compose/src/main/java/com/ketch/android/sample/compose/DevUrlOverrides.kt
@@ -1,0 +1,16 @@
+package com.ketch.android.sample.compose
+
+/**
+ * Flip [ENABLED] to redirect UAT tag script URLs to a local dev server (e.g. `ketch-js` on :9000).
+ * Android emulator: use [forEmulator] — `10.0.2.2` is the emulator's alias for the host machine's
+ * loopback interface (plain `localhost` from inside the emulator resolves to the emulator itself).
+ * Physical device: substitute the host machine's LAN IP for `10.0.2.2` below.
+ */
+object DevUrlOverrides {
+    const val ENABLED = false
+
+    val forEmulator: Map<String, String> = mapOf(
+        "https://cdn.uat.ketchjs.com/ketchtag/stable/v2.12/ketch-sdk.js" to "http://10.0.2.2:9000/ketch-sdk.js",
+        "ketch-sdk.js" to "http://10.0.2.2:9000/ketch-sdk.js",
+    )
+}

--- a/sample-app-compose/src/main/java/com/ketch/android/sample/compose/KetchSampleApp.kt
+++ b/sample-app-compose/src/main/java/com/ketch/android/sample/compose/KetchSampleApp.kt
@@ -26,8 +26,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
@@ -35,6 +37,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -44,6 +47,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.ketch.android.Ketch
 import com.ketch.android.sample.compose.ui.theme.DarkDivider
 import com.ketch.android.sample.compose.ui.theme.DarkLogBackground
 import com.ketch.android.sample.compose.ui.theme.DarkLogText
@@ -57,13 +61,35 @@ import com.ketch.android.sample.compose.ui.theme.LightToggleTrack
 
 @Composable
 fun KetchSampleApp(
+    orgCode: String,
+    property: String,
+    environment: String,
+    language: String,
+    jurisdiction: String,
+    region: String,
     logEntries: List<String>,
+    onReload: () -> Unit,
     onShowConsent: () -> Unit,
-    onShowPreferences: () -> Unit,
+    onShowPreferences: (allowedTabs: List<Ketch.PreferencesTab>, initialTab: Ketch.PreferencesTab) -> Unit,
+    onApplyCss: () -> Unit,
     onOpenSecondActivity: () -> Unit,
     onLogSharedPreferences: () -> Unit,
 ) {
     var isDarkMode by rememberSaveable { mutableStateOf(false) }
+
+    // Preference Options state (mirrors iOS/Flutter/RN samples' allowed-tabs + initial-tab pickers).
+    var showOverview by remember { mutableStateOf(true) }
+    var showConsents by remember { mutableStateOf(true) }
+    var showRights by remember { mutableStateOf(true) }
+    var showSubscriptions by remember { mutableStateOf(true) }
+    var initialTab by remember { mutableStateOf(Ketch.PreferencesTab.OVERVIEW) }
+
+    fun allowedTabs(): List<Ketch.PreferencesTab> = buildList {
+        if (showOverview) add(Ketch.PreferencesTab.OVERVIEW)
+        if (showConsents) add(Ketch.PreferencesTab.CONSENTS)
+        if (showRights) add(Ketch.PreferencesTab.RIGHTS)
+        if (showSubscriptions) add(Ketch.PreferencesTab.SUBSCRIPTIONS)
+    }
 
     KetchTheme(darkTheme = isDarkMode) {
         Column(
@@ -88,14 +114,58 @@ fun KetchSampleApp(
                     .verticalScroll(rememberScrollState())
                     .padding(20.dp)
             ) {
-                SectionHeader("Experience Functions")
+                SectionHeader("Info")
+                Spacer(Modifier.height(12.dp))
+                InfoPanel(
+                    orgCode = orgCode,
+                    property = property,
+                    environment = environment,
+                    language = language,
+                    jurisdiction = jurisdiction,
+                    region = region,
+                )
+                Spacer(Modifier.height(24.dp))
+                SectionHeader("Preference Options")
+                Spacer(Modifier.height(12.dp))
+                PreferenceOptions(
+                    showOverview = showOverview,
+                    onShowOverviewChange = { showOverview = it },
+                    showConsents = showConsents,
+                    onShowConsentsChange = { showConsents = it },
+                    showRights = showRights,
+                    onShowRightsChange = { showRights = it },
+                    showSubscriptions = showSubscriptions,
+                    onShowSubscriptionsChange = { showSubscriptions = it },
+                    initialTab = initialTab,
+                    onInitialTabChange = { initialTab = it },
+                )
+                Spacer(Modifier.height(24.dp))
+                SectionHeader("Actions")
                 Spacer(Modifier.height(16.dp))
                 CardsRow(
                     onShowConsent = onShowConsent,
-                    onShowPreferences = onShowPreferences
+                    onShowPreferences = { onShowPreferences(allowedTabs(), initialTab) }
                 )
+                Spacer(Modifier.height(16.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    ActionCard(
+                        title = "Reload",
+                        description = "Reload the SDK boot config and refresh privacy state.",
+                        onExecute = onReload,
+                        modifier = Modifier.weight(1f),
+                    )
+                    ActionCard(
+                        title = "Apply CSS",
+                        description = "Apply a sample CSS style override to the experience.",
+                        onExecute = onApplyCss,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
                 Spacer(Modifier.height(24.dp))
-                SectionHeader("Debug")
+                SectionHeader("Privacy Strings")
                 Spacer(Modifier.height(12.dp))
                 ActionCard(
                     title = "Shared Preferences",
@@ -124,6 +194,121 @@ fun KetchSampleApp(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun InfoPanel(
+    orgCode: String,
+    property: String,
+    environment: String,
+    language: String,
+    jurisdiction: String,
+    region: String,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(
+                BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+                RoundedCornerShape(12.dp)
+            )
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(16.dp)
+    ) {
+        InfoRow("Org Code", orgCode)
+        InfoRow("Property", property)
+        InfoRow("Environment", environment)
+        InfoRow("Language", language)
+        InfoRow("Jurisdiction", jurisdiction)
+        InfoRow("Region", region)
+    }
+}
+
+@Composable
+private fun InfoRow(label: String, value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+    ) {
+        Text(
+            text = label,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = value,
+            fontSize = 13.sp,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun PreferenceOptions(
+    showOverview: Boolean,
+    onShowOverviewChange: (Boolean) -> Unit,
+    showConsents: Boolean,
+    onShowConsentsChange: (Boolean) -> Unit,
+    showRights: Boolean,
+    onShowRightsChange: (Boolean) -> Unit,
+    showSubscriptions: Boolean,
+    onShowSubscriptionsChange: (Boolean) -> Unit,
+    initialTab: Ketch.PreferencesTab,
+    onInitialTabChange: (Ketch.PreferencesTab) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(
+                BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+                RoundedCornerShape(12.dp)
+            )
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "Allowed tabs",
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        TabCheckbox("Overview", showOverview, onShowOverviewChange)
+        TabCheckbox("Consent", showConsents, onShowConsentsChange)
+        TabCheckbox("Rights", showRights, onShowRightsChange)
+        TabCheckbox("Subscriptions", showSubscriptions, onShowSubscriptionsChange)
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = "Initial tab",
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        TabRadio("Overview", initialTab == Ketch.PreferencesTab.OVERVIEW) { onInitialTabChange(Ketch.PreferencesTab.OVERVIEW) }
+        TabRadio("Consent", initialTab == Ketch.PreferencesTab.CONSENTS) { onInitialTabChange(Ketch.PreferencesTab.CONSENTS) }
+        TabRadio("Rights", initialTab == Ketch.PreferencesTab.RIGHTS) { onInitialTabChange(Ketch.PreferencesTab.RIGHTS) }
+        TabRadio("Subscriptions", initialTab == Ketch.PreferencesTab.SUBSCRIPTIONS) { onInitialTabChange(Ketch.PreferencesTab.SUBSCRIPTIONS) }
+    }
+}
+
+@Composable
+private fun TabCheckbox(label: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Checkbox(checked = checked, onCheckedChange = onCheckedChange)
+        Text(label, fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurface)
+    }
+}
+
+@Composable
+private fun TabRadio(label: String, selected: Boolean, onClick: () -> Unit) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        RadioButton(selected = selected, onClick = onClick)
+        Text(label, fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurface)
     }
 }
 

--- a/sample-app-compose/src/main/java/com/ketch/android/sample/compose/MainActivity.kt
+++ b/sample-app-compose/src/main/java/com/ketch/android/sample/compose/MainActivity.kt
@@ -19,6 +19,7 @@ class MainActivity : AppCompatActivity() {
     companion object {
         private const val TAG = "KetchCompose"
         private val IAB_PREFERENCE_PREFIXES = listOf("IABTCF", "IABGPP", "IABUS")
+        private const val SAMPLE_CSS_OVERRIDE = "body { --ketch-brand-color: #6B4EE6; }"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -35,16 +36,32 @@ class MainActivity : AppCompatActivity() {
 
         setContent {
             KetchSampleApp(
+                orgCode = SampleConfig.ORG_CODE,
+                property = SampleConfig.PROPERTY,
+                environment = SampleConfig.ENVIRONMENT,
+                language = SampleConfig.LANGUAGE,
+                jurisdiction = app.infoState.jurisdiction,
+                region = app.infoState.region,
                 logEntries = logEntries,
+                onReload = {
+                    Log.d(TAG, "load() called")
+                    logEntries.add("load() called")
+                    ketch.load()
+                },
                 onShowConsent = {
                     Log.d(TAG, "showConsent() called")
                     logEntries.add("showConsent() called")
                     ketch.showConsent()
                 },
-                onShowPreferences = {
-                    Log.d(TAG, "showPreferences() called")
-                    logEntries.add("showPreferences() called")
-                    ketch.showPreferences()
+                onShowPreferences = { allowedTabs, initialTab ->
+                    Log.d(TAG, "showPreferencesTab() called: tabs=$allowedTabs, initial=$initialTab")
+                    logEntries.add("showPreferencesTab() called: tabs=$allowedTabs, initial=$initialTab")
+                    ketch.showPreferencesTab(allowedTabs, initialTab)
+                },
+                onApplyCss = {
+                    Log.d(TAG, "setCssStyle() called")
+                    logEntries.add("setCssStyle() called")
+                    ketch.setCssStyle(SAMPLE_CSS_OVERRIDE)
                 },
                 onOpenSecondActivity = {
                     logEntries.add("Opening SecondActivity")

--- a/sample-app-compose/src/main/java/com/ketch/android/sample/compose/SampleConfig.kt
+++ b/sample-app-compose/src/main/java/com/ketch/android/sample/compose/SampleConfig.kt
@@ -1,0 +1,16 @@
+package com.ketch.android.sample.compose
+
+import com.ketch.android.api.KetchDataCenter
+
+/**
+ * Single source of truth for both SDK init and the Info panel (mirrors iOS `SampleConfig` /
+ * Flutter `sampleConfig` / React-Native `SAMPLE_CONFIG`).
+ */
+object SampleConfig {
+    const val ORG_CODE = "ketch_samples"
+    const val PROPERTY = "android"
+    const val ENVIRONMENT = "production"
+    const val LANGUAGE = "en"
+    val dataCenter: KetchDataCenter = KetchDataCenter.US
+    val identities: Map<String, String> = mapOf("aaid" to "sample-test-123")
+}

--- a/sample-app-compose/src/main/java/com/ketch/android/sample/compose/SampleInfoState.kt
+++ b/sample-app-compose/src/main/java/com/ketch/android/sample/compose/SampleInfoState.kt
@@ -1,0 +1,25 @@
+package com.ketch.android.sample.compose
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+/**
+ * Live SDK state bound to the Info panel (mirrors iOS `SampleInfoState` / React-Native
+ * `InfoContext`). Only jurisdiction/region are surfaced on screen; every other callback goes to
+ * logcat via the shared [Ketch.Listener] in [ComposeSampleApplication].
+ */
+class SampleInfoState {
+    var jurisdiction: String by mutableStateOf("Not set")
+        private set
+    var region: String by mutableStateOf("Not set")
+        private set
+
+    fun updateJurisdiction(value: String?) {
+        jurisdiction = value?.takeIf { it.isNotBlank() } ?: "Not set"
+    }
+
+    fun updateRegion(value: String?) {
+        region = value?.takeIf { it.isNotBlank() } ?: "Not set"
+    }
+}

--- a/sample-app-compose/src/main/java/com/ketch/android/sample/compose/SampleLogging.kt
+++ b/sample-app-compose/src/main/java/com/ketch/android/sample/compose/SampleLogging.kt
@@ -1,0 +1,23 @@
+package com.ketch.android.sample.compose
+
+import com.ketch.android.data.Consent
+
+/**
+ * Formats consent for the event log (mirrors iOS `SampleLogging.swift` / React-Native
+ * `consentLogging.ts`): allowed/denied purposes, vendors, and protocol strings.
+ */
+fun formatConsent(consent: Consent): String {
+    val purposes = consent.purposes.orEmpty()
+    val allowed = purposes.filterValues { it }.keys.sorted()
+    val denied = purposes.filterValues { !it }.keys.sorted()
+    return buildString {
+        append("allowed=[").append(allowed.joinToString(",")).append("]")
+        append(" denied=[").append(denied.joinToString(",")).append("]")
+        consent.vendors?.takeIf { it.isNotEmpty() }?.let {
+            append(" vendors=[").append(it.joinToString(",")).append("]")
+        }
+        consent.protocols?.takeIf { it.isNotEmpty() }?.let {
+            append(" protocols=[").append(it.entries.joinToString(",") { e -> "${e.key}=${e.value}" }).append("]")
+        }
+    }
+}

--- a/sample-app-compose/src/main/res/xml/network_security_config.xml
+++ b/sample-app-compose/src/main/res/xml/network_security_config.xml
@@ -3,6 +3,8 @@
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">ketchcdn.com</domain>
         <domain includeSubdomains="true">global.ketchcdn.com</domain>
+        <domain includeSubdomains="true">10.0.2.2</domain>
+        <domain includeSubdomains="true">localhost</domain>
     </domain-config>
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>

--- a/sample-app-standard/src/main/java/com/ketch/android/sample/standard/DevUrlOverrides.kt
+++ b/sample-app-standard/src/main/java/com/ketch/android/sample/standard/DevUrlOverrides.kt
@@ -1,0 +1,16 @@
+package com.ketch.android.sample.standard
+
+/**
+ * Flip [ENABLED] to redirect UAT tag script URLs to a local dev server (e.g. `ketch-js` on :9000).
+ * Android emulator: use [forEmulator] — `10.0.2.2` is the emulator's alias for the host machine's
+ * loopback interface (plain `localhost` from inside the emulator resolves to the emulator itself).
+ * Physical device: substitute the host machine's LAN IP for `10.0.2.2` below.
+ */
+object DevUrlOverrides {
+    const val ENABLED = false
+
+    val forEmulator: Map<String, String> = mapOf(
+        "https://cdn.uat.ketchjs.com/ketchtag/stable/v2.12/ketch-sdk.js" to "http://10.0.2.2:9000/ketch-sdk.js",
+        "ketch-sdk.js" to "http://10.0.2.2:9000/ketch-sdk.js",
+    )
+}

--- a/sample-app-standard/src/main/java/com/ketch/android/sample/standard/MainActivity.kt
+++ b/sample-app-standard/src/main/java/com/ketch/android/sample/standard/MainActivity.kt
@@ -23,6 +23,7 @@ class MainActivity : AppCompatActivity() {
     companion object {
         private const val TAG = "KetchSample"
         private val IAB_PREFERENCE_PREFIXES = listOf("IABTCF", "IABGPP", "IABUS")
+        private const val SAMPLE_CSS_OVERRIDE = "body { --ketch-brand-color: #6B4EE6; }"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -36,6 +37,7 @@ class MainActivity : AppCompatActivity() {
         app = application as SampleApplication
         ketch = app.ketch
         app.logCallback = { message -> appendLog(message) }
+        app.infoState.onChange = { runOnUiThread { renderInfoPanel() } }
 
         ViewCompat.setOnApplyWindowInsetsListener(binding.rootLayout) { view, windowInsets ->
             val insets = windowInsets.getInsets(
@@ -52,6 +54,8 @@ class MainActivity : AppCompatActivity() {
         }
 
         setupDarkModeToggle()
+        renderStaticInfo()
+        renderInfoPanel()
         initializeKetch()
         setupClickListeners()
     }
@@ -59,8 +63,21 @@ class MainActivity : AppCompatActivity() {
     override fun onDestroy() {
         if (isFinishing) {
             app.logCallback = null
+            app.infoState.onChange = null
         }
         super.onDestroy()
+    }
+
+    private fun renderStaticInfo() {
+        binding.infoOrgCodeValue.text = SampleConfig.ORG_CODE
+        binding.infoPropertyValue.text = SampleConfig.PROPERTY
+        binding.infoEnvironmentValue.text = SampleConfig.ENVIRONMENT
+        binding.infoLanguageValue.text = SampleConfig.LANGUAGE
+    }
+
+    private fun renderInfoPanel() {
+        binding.infoJurisdictionValue.text = app.infoState.jurisdiction
+        binding.infoRegionValue.text = app.infoState.region
     }
 
     private fun setupDarkModeToggle() {
@@ -89,9 +106,23 @@ class MainActivity : AppCompatActivity() {
         }
 
         binding.showPreferencesButton.setOnClickListener {
-            Log.d(TAG, "showPreferences() called")
-            appendLog("showPreferences() called")
-            ketch.showPreferences()
+            val allowedTabs = allowedTabs()
+            val initialTab = initialTab()
+            Log.d(TAG, "showPreferencesTab() called: tabs=$allowedTabs, initial=$initialTab")
+            appendLog("showPreferencesTab() called: tabs=$allowedTabs, initial=$initialTab")
+            ketch.showPreferencesTab(allowedTabs, initialTab)
+        }
+
+        binding.reloadButton.setOnClickListener {
+            Log.d(TAG, "load() called")
+            appendLog("load() called")
+            ketch.load()
+        }
+
+        binding.applyCssButton.setOnClickListener {
+            Log.d(TAG, "setCssStyle() called")
+            appendLog("setCssStyle() called")
+            ketch.setCssStyle(SAMPLE_CSS_OVERRIDE)
         }
 
         binding.openSecondActivityButton.setOnClickListener {
@@ -102,6 +133,20 @@ class MainActivity : AppCompatActivity() {
         binding.logSharedPreferencesButton.setOnClickListener {
             logSharedPreferences()
         }
+    }
+
+    private fun allowedTabs(): List<Ketch.PreferencesTab> = buildList {
+        if (binding.prefTabOverviewCheck.isChecked) add(Ketch.PreferencesTab.OVERVIEW)
+        if (binding.prefTabConsentCheck.isChecked) add(Ketch.PreferencesTab.CONSENTS)
+        if (binding.prefTabRightsCheck.isChecked) add(Ketch.PreferencesTab.RIGHTS)
+        if (binding.prefTabSubscriptionsCheck.isChecked) add(Ketch.PreferencesTab.SUBSCRIPTIONS)
+    }
+
+    private fun initialTab(): Ketch.PreferencesTab = when (binding.prefInitialTabGroup.checkedRadioButtonId) {
+        binding.prefTabConsentRadio.id -> Ketch.PreferencesTab.CONSENTS
+        binding.prefTabRightsRadio.id -> Ketch.PreferencesTab.RIGHTS
+        binding.prefTabSubscriptionsRadio.id -> Ketch.PreferencesTab.SUBSCRIPTIONS
+        else -> Ketch.PreferencesTab.OVERVIEW
     }
 
     private fun logSharedPreferences() {

--- a/sample-app-standard/src/main/java/com/ketch/android/sample/standard/SampleApplication.kt
+++ b/sample-app-standard/src/main/java/com/ketch/android/sample/standard/SampleApplication.kt
@@ -14,20 +14,24 @@ class SampleApplication : Application() {
     lateinit var ketch: Ketch
         private set
 
+    val infoState = SampleInfoState()
+
     var logCallback: ((String) -> Unit)? = null
 
     override fun onCreate() {
         super.onCreate()
         ketch = KetchSdk.create(
             context = this,
-            organization = ORG_CODE,
-            property = PROPERTY,
-            environment = ENVIRONMENT,
+            organization = SampleConfig.ORG_CODE,
+            property = SampleConfig.PROPERTY,
+            environment = SampleConfig.ENVIRONMENT,
             listener = sharedListener,
-            ketchUrl = null,
+            ketchUrl = SampleConfig.dataCenter.baseUrl,
             logLevel = Ketch.LogLevel.DEBUG,
+            webResourceUrlOverrides = if (DevUrlOverrides.ENABLED) DevUrlOverrides.forEmulator else emptyMap(),
         )
-        ketch.setIdentities(mapOf("aaid" to "sample-test-123"))
+        ketch.setLanguage(SampleConfig.LANGUAGE)
+        ketch.setIdentities(SampleConfig.identities)
     }
 
     private val sharedListener = object : Ketch.Listener {
@@ -54,11 +58,13 @@ class SampleApplication : Application() {
         override fun onRegionInfoUpdated(regionInfo: String?) {
             Log.d(TAG, "onRegionInfoUpdated: $regionInfo")
             log("onRegionInfoUpdated: $regionInfo")
+            infoState.updateRegion(regionInfo)
         }
 
         override fun onJurisdictionUpdated(jurisdiction: String?) {
             Log.d(TAG, "onJurisdictionUpdated: $jurisdiction")
             log("onJurisdictionUpdated: $jurisdiction")
+            infoState.updateJurisdiction(jurisdiction)
         }
 
         override fun onIdentitiesUpdated(identities: String?) {
@@ -67,8 +73,9 @@ class SampleApplication : Application() {
         }
 
         override fun onConsentUpdated(consent: Consent) {
-            Log.d(TAG, "onConsentUpdated: purposes=${consent.purposes}")
-            log("onConsentUpdated: ${consent.purposes}")
+            val summary = formatConsent(consent)
+            Log.d(TAG, "onConsentUpdated: $summary")
+            log("onConsentUpdated: $summary")
         }
 
         override fun onError(errMsg: String?) {
@@ -108,8 +115,5 @@ class SampleApplication : Application() {
 
     companion object {
         private const val TAG = "KetchSample"
-        const val ORG_CODE = "ketch_samples"
-        const val PROPERTY = "android"
-        const val ENVIRONMENT = "production"
     }
 }

--- a/sample-app-standard/src/main/java/com/ketch/android/sample/standard/SampleConfig.kt
+++ b/sample-app-standard/src/main/java/com/ketch/android/sample/standard/SampleConfig.kt
@@ -1,0 +1,16 @@
+package com.ketch.android.sample.standard
+
+import com.ketch.android.api.KetchDataCenter
+
+/**
+ * Single source of truth for both SDK init and the Info panel (mirrors iOS `SampleConfig` /
+ * Flutter `sampleConfig` / React-Native `SAMPLE_CONFIG`).
+ */
+object SampleConfig {
+    const val ORG_CODE = "ketch_samples"
+    const val PROPERTY = "android"
+    const val ENVIRONMENT = "production"
+    const val LANGUAGE = "en"
+    val dataCenter: KetchDataCenter = KetchDataCenter.US
+    val identities: Map<String, String> = mapOf("aaid" to "sample-test-123")
+}

--- a/sample-app-standard/src/main/java/com/ketch/android/sample/standard/SampleInfoState.kt
+++ b/sample-app-standard/src/main/java/com/ketch/android/sample/standard/SampleInfoState.kt
@@ -1,0 +1,26 @@
+package com.ketch.android.sample.standard
+
+/**
+ * Live SDK state bound to the Info panel (mirrors iOS `SampleInfoState` / React-Native
+ * `InfoContext`). Only jurisdiction/region are surfaced on screen; every other callback goes to
+ * logcat via the shared [com.ketch.android.Ketch.Listener] in [SampleApplication].
+ */
+class SampleInfoState {
+    var jurisdiction: String = "Not set"
+        private set
+    var region: String = "Not set"
+        private set
+
+    /** Invoked on the main thread whenever [jurisdiction] or [region] changes. */
+    var onChange: (() -> Unit)? = null
+
+    fun updateJurisdiction(value: String?) {
+        jurisdiction = value?.takeIf { it.isNotBlank() } ?: "Not set"
+        onChange?.invoke()
+    }
+
+    fun updateRegion(value: String?) {
+        region = value?.takeIf { it.isNotBlank() } ?: "Not set"
+        onChange?.invoke()
+    }
+}

--- a/sample-app-standard/src/main/java/com/ketch/android/sample/standard/SampleLogging.kt
+++ b/sample-app-standard/src/main/java/com/ketch/android/sample/standard/SampleLogging.kt
@@ -1,0 +1,23 @@
+package com.ketch.android.sample.standard
+
+import com.ketch.android.data.Consent
+
+/**
+ * Formats consent for the event log (mirrors iOS `SampleLogging.swift` / React-Native
+ * `consentLogging.ts`): allowed/denied purposes, vendors, and protocol strings.
+ */
+fun formatConsent(consent: Consent): String {
+    val purposes = consent.purposes.orEmpty()
+    val allowed = purposes.filterValues { it }.keys.sorted()
+    val denied = purposes.filterValues { !it }.keys.sorted()
+    return buildString {
+        append("allowed=[").append(allowed.joinToString(",")).append("]")
+        append(" denied=[").append(denied.joinToString(",")).append("]")
+        consent.vendors?.takeIf { it.isNotEmpty() }?.let {
+            append(" vendors=[").append(it.joinToString(",")).append("]")
+        }
+        consent.protocols?.takeIf { it.isNotEmpty() }?.let {
+            append(" protocols=[").append(it.entries.joinToString(",") { e -> "${e.key}=${e.value}" }).append("]")
+        }
+    }
+}

--- a/sample-app-standard/src/main/res/layout/activity_main.xml
+++ b/sample-app-standard/src/main/res/layout/activity_main.xml
@@ -70,11 +70,258 @@
             android:orientation="vertical"
             android:padding="20dp">
 
+            <!-- Info section -->
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Info"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                android:textColor="@color/ketch_purple"
+                android:drawableStart="@android:drawable/arrow_down_float"
+                android:drawablePadding="4dp"
+                android:drawableTint="@color/ketch_purple"
+                android:layout_marginBottom="12dp" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:background="@drawable/card_background"
+                android:padding="16dp"
+                android:layout_marginBottom="24dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:paddingVertical="4dp">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Org Code"
+                        android:textSize="13sp"
+                        android:textColor="@color/text_secondary" />
+                    <TextView
+                        android:id="@+id/infoOrgCodeValue"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textSize="13sp"
+                        android:textColor="@color/text_primary" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:paddingVertical="4dp">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Property"
+                        android:textSize="13sp"
+                        android:textColor="@color/text_secondary" />
+                    <TextView
+                        android:id="@+id/infoPropertyValue"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textSize="13sp"
+                        android:textColor="@color/text_primary" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:paddingVertical="4dp">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Environment"
+                        android:textSize="13sp"
+                        android:textColor="@color/text_secondary" />
+                    <TextView
+                        android:id="@+id/infoEnvironmentValue"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textSize="13sp"
+                        android:textColor="@color/text_primary" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:paddingVertical="4dp">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Language"
+                        android:textSize="13sp"
+                        android:textColor="@color/text_secondary" />
+                    <TextView
+                        android:id="@+id/infoLanguageValue"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textSize="13sp"
+                        android:textColor="@color/text_primary" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:paddingVertical="4dp">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Jurisdiction"
+                        android:textSize="13sp"
+                        android:textColor="@color/text_secondary" />
+                    <TextView
+                        android:id="@+id/infoJurisdictionValue"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Not set"
+                        android:textSize="13sp"
+                        android:textColor="@color/text_primary" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:paddingVertical="4dp">
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Region"
+                        android:textSize="13sp"
+                        android:textColor="@color/text_secondary" />
+                    <TextView
+                        android:id="@+id/infoRegionValue"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Not set"
+                        android:textSize="13sp"
+                        android:textColor="@color/text_primary" />
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <!-- Preference Options section -->
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Preference Options"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                android:textColor="@color/ketch_purple"
+                android:drawableStart="@android:drawable/arrow_down_float"
+                android:drawablePadding="4dp"
+                android:drawableTint="@color/ketch_purple"
+                android:layout_marginBottom="12dp" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:background="@drawable/card_background"
+                android:padding="16dp"
+                android:layout_marginBottom="24dp">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Allowed tabs"
+                    android:textSize="13sp"
+                    android:textStyle="bold"
+                    android:textColor="@color/text_secondary"
+                    android:layout_marginBottom="4dp" />
+
+                <CheckBox
+                    android:id="@+id/prefTabOverviewCheck"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Overview"
+                    android:checked="true" />
+
+                <CheckBox
+                    android:id="@+id/prefTabConsentCheck"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Consent"
+                    android:checked="true" />
+
+                <CheckBox
+                    android:id="@+id/prefTabRightsCheck"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Rights"
+                    android:checked="true" />
+
+                <CheckBox
+                    android:id="@+id/prefTabSubscriptionsCheck"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Subscriptions"
+                    android:checked="true" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Initial tab"
+                    android:textSize="13sp"
+                    android:textStyle="bold"
+                    android:textColor="@color/text_secondary"
+                    android:layout_marginTop="12dp"
+                    android:layout_marginBottom="4dp" />
+
+                <RadioGroup
+                    android:id="@+id/prefInitialTabGroup"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <RadioButton
+                        android:id="@+id/prefTabOverviewRadio"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="Overview"
+                        android:checked="true" />
+
+                    <RadioButton
+                        android:id="@+id/prefTabConsentRadio"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="Consent" />
+
+                    <RadioButton
+                        android:id="@+id/prefTabRightsRadio"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="Rights" />
+
+                    <RadioButton
+                        android:id="@+id/prefTabSubscriptionsRadio"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="Subscriptions" />
+
+                </RadioGroup>
+
+            </LinearLayout>
+
             <!-- Section header -->
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Experience Functions"
+                android:text="Actions"
                 android:textSize="18sp"
                 android:textStyle="bold"
                 android:textColor="@color/ketch_purple"
@@ -167,11 +414,93 @@
 
             </LinearLayout>
 
-            <!-- Debug section -->
+            <!-- Reload / Apply CSS row -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginBottom="24dp"
+                android:baselineAligned="false">
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:orientation="vertical"
+                    android:background="@drawable/card_background"
+                    android:padding="16dp"
+                    android:layout_marginEnd="8dp">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="Reload"
+                        android:textSize="15sp"
+                        android:textStyle="bold"
+                        android:textColor="@color/text_primary"
+                        android:layout_marginBottom="8dp" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="0dp"
+                        android:layout_weight="1"
+                        android:text="Reload the SDK boot config and refresh privacy state."
+                        android:textSize="13sp"
+                        android:textColor="@color/text_secondary"
+                        android:layout_marginBottom="12dp" />
+
+                    <Button
+                        android:id="@+id/reloadButton"
+                        style="@style/Widget.KetchSample.Button.Execute"
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:text="Execute" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:orientation="vertical"
+                    android:background="@drawable/card_background"
+                    android:padding="16dp"
+                    android:layout_marginStart="8dp">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="Apply CSS"
+                        android:textSize="15sp"
+                        android:textStyle="bold"
+                        android:textColor="@color/text_primary"
+                        android:layout_marginBottom="8dp" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="0dp"
+                        android:layout_weight="1"
+                        android:text="Apply a sample CSS style override to the experience."
+                        android:textSize="13sp"
+                        android:textColor="@color/text_secondary"
+                        android:layout_marginBottom="12dp" />
+
+                    <Button
+                        android:id="@+id/applyCssButton"
+                        style="@style/Widget.KetchSample.Button.Execute"
+                        android:layout_width="wrap_content"
+                        android:layout_height="40dp"
+                        android:text="Execute" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <!-- Privacy Strings section -->
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Debug"
+                android:text="Privacy Strings"
                 android:textSize="18sp"
                 android:textStyle="bold"
                 android:textColor="@color/ketch_purple"

--- a/sample-app-standard/src/main/res/xml/network_security_config.xml
+++ b/sample-app-standard/src/main/res/xml/network_security_config.xml
@@ -3,6 +3,8 @@
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">ketchcdn.com</domain>
         <domain includeSubdomains="true">global.ketchcdn.com</domain>
+        <domain includeSubdomains="true">10.0.2.2</domain>
+        <domain includeSubdomains="true">localhost</domain>
     </domain-config>
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> Description here

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New optional public API and WebView resource interception affect consent/tag loading; defaults are empty so production behavior is unchanged, but integrators using overrides or the sample cleartext dev paths should validate WebView flows.
> 
> **Overview**
> Aligns the **compose** and **standard** sample apps with the other Ketch mobile samples: shared `SampleConfig`, an **Info** panel (including live jurisdiction/region), **Preference Options** that drive `showPreferencesTab`, plus **Reload**, **Apply CSS**, and richer consent logging. Init now uses `KetchDataCenter` for `ketchUrl` and optional `DevUrlOverrides` for local tag scripts (with cleartext allowed for emulator localhost).
> 
> On the SDK side, this introduces **`webResourceUrlOverrides`** on `KetchSdk`/`Ketch` (`setWebResourceUrlOverrides`), wired through boot HTML (JS `fetch`/script `src` hooks) and **`shouldInterceptRequest`** via `WebResourceOverrideHandler` / `WebResourceUrlOverrideResolver`. A public **`KetchDataCenter`** enum documents US/EU/UAT CDN base URLs.
> 
> Developer workflow adds the **`/ketch-android-run-sample`** skill: scripts to flip sample Gradle deps between `:ketchsdk` and published Maven, boot an emulator, build/install, and stream logcat; `development-workflow.mdc` points to it for release verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ddbe3caa74d514cd11c764268a1f69fbeb5a057. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->