### PR TITLE
fix(android): scope WebView teardown to the owning Activity

### DIFF
--- a/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/KetchSdkIntegrationTest.kt
+++ b/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/KetchSdkIntegrationTest.kt
@@ -527,14 +527,14 @@ class KetchSdkIntegrationTest {
         assertTrue("Banner should be shown", bannerShown)
         assertTrue("Banner should be validated", bannerValidated)
         
-        // Phase 2: Click "Opt Out" button (primary button)
+        // Phase 2: Click "Opt Out" button (tertiary button = "Reject All" per the deployment plan)
         val optOutLatch = CountDownLatch(1)
         scenario.onActivity { activity ->
-            activity.clickButtonById("ketch-banner-button-primary") { clicked ->
+            activity.clickButtonById("ketch-banner-button-tertiary") { clicked ->
                 if (clicked) {
                     optOutLatch.countDown()
                 } else {
-                    fail("Failed to click 'Opt Out' button (ketch-banner-button-primary)")
+                    fail("Failed to click 'Opt Out' button (ketch-banner-button-tertiary)")
                 }
             }
             optOutConsentRequested = true
@@ -574,14 +574,14 @@ class KetchSdkIntegrationTest {
         assertTrue("Banner should be shown again", bannerShownAgain)
         assertTrue("Banner should be validated again", bannerValidatedAgain)
         
-        // Phase 4: Click "Opt In" button (tertiary button)
+        // Phase 4: Click "Opt In" button (primary button = "Accept All" per the deployment plan)
         val optInLatch = CountDownLatch(1)
         scenario.onActivity { activity ->
-            activity.clickButtonById("ketch-banner-button-tertiary") { clicked ->
+            activity.clickButtonById("ketch-banner-button-primary") { clicked ->
                 if (clicked) {
                     optInLatch.countDown()
                 } else {
-                    fail("Failed to click 'Opt In' button (ketch-banner-button-tertiary)")
+                    fail("Failed to click 'Opt In' button (ketch-banner-button-primary)")
                 }
             }
             optInConsentRequested = true

--- a/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/ZTransientActivityLoadSurvivesTest.kt
+++ b/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/ZTransientActivityLoadSurvivesTest.kt
@@ -1,0 +1,80 @@
+package com.ketch.android.integration.tests
+
+import android.content.Intent
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.pressBackUnconditionally
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * A transient Activity calls load() and finishes before the boot completes, while a
+ * different (still-alive) Activity is the one that actually owns the in-flight WebView.
+ * Verifies the boot survives the transient Activity's destroy instead of being killed.
+ */
+@RunWith(AndroidJUnit4::class)
+class ZTransientActivityLoadSurvivesTest {
+
+    private lateinit var app: IntegrationTestApp
+    private lateinit var mainScenario: ActivityScenario<MainActivity>
+
+    @Before
+    fun setUp() {
+        app = ApplicationProvider.getApplicationContext() as IntegrationTestApp
+        repeat(3) {
+            try {
+                pressBackUnconditionally()
+            } catch (_: Exception) {
+            }
+        }
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            app.ketch.dismissDialog()
+            app.ketch.setIdentities(mapOf("aaid" to "test-123"))
+        }
+        mainScenario = ActivityScenario.launch(MainActivity::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        app.clearTestMode()
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            app.ketch.dismissDialog()
+            app.ketch.setIdentities(mapOf("aaid" to "test-123"))
+        }
+        repeat(3) {
+            try {
+                pressBackUnconditionally()
+            } catch (_: Exception) {
+            }
+        }
+        mainScenario.close()
+    }
+
+    @Test
+    fun transientActivityFinishing_doesNotKillLoadStartedWhileMainActivityWasCurrent() {
+        val configUpdatedLatch = CountDownLatch(1)
+        app.setTestMode(object : IntegrationTestApp.TestEventListener {
+            override fun onConfigUpdated() {
+                configUpdatedLatch.countDown()
+            }
+        })
+
+        mainScenario.onActivity { it.updateIdentitiesWithUniqueValue() }
+        mainScenario.onActivity { activity ->
+            activity.startActivity(Intent(activity, TransientLoadActivity::class.java))
+        }
+
+        assertTrue(
+            "onConfigUpdated should fire within 30s even though TransientLoadActivity " +
+                "finished before the boot completed",
+            configUpdatedLatch.await(30, TimeUnit.SECONDS)
+        )
+    }
+}

--- a/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/ZTriggerFunctionTest.kt
+++ b/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/ZTriggerFunctionTest.kt
@@ -8,6 +8,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.ketch.android.TriggerName
+import com.ketch.android.data.HideExperienceStatus
 import com.ketch.android.data.WillShowExperienceType
 import org.junit.After
 import org.junit.Assert.assertFalse
@@ -81,6 +82,25 @@ class ZTriggerFunctionTest {
     @Test
     fun warmWebView_dispatchesTriggerWithoutError() {
         showConsentBannerAndWait()
+
+        // trigger() intentionally refuses to dispatch while an experience is showing
+        // (Ketch.kt) — dismiss via a banner button (setConsent) first, which retains the
+        // WebView (unlike dismissDialog(), which destroys it), so it stays warm.
+        val dismissLatch = CountDownLatch(1)
+        app.setTestMode(object : IntegrationTestApp.TestEventListener {
+            override fun onDismiss(status: HideExperienceStatus) {
+                dismissLatch.countDown()
+            }
+        })
+        val clickLatch = CountDownLatch(1)
+        scenario.onActivity { activity ->
+            activity.clickButtonById("ketch-banner-button-primary") { clicked ->
+                if (clicked) clickLatch.countDown()
+            }
+        }
+        assertTrue("Banner button should be clicked", clickLatch.await(10, TimeUnit.SECONDS))
+        assertTrue("Banner should dismiss within 10s", dismissLatch.await(10, TimeUnit.SECONDS))
+        assertTrue("WebView should be retained after dismiss", app.hasActiveWebView())
 
         val errorLatch = CountDownLatch(1)
         app.setTestMode(object : IntegrationTestApp.TestEventListener {

--- a/integration-tests/src/main/AndroidManifest.xml
+++ b/integration-tests/src/main/AndroidManifest.xml
@@ -32,6 +32,10 @@
             android:name=".SecondActivity"
             android:exported="false"
             android:theme="@style/Theme.KetchIntegrationTests" />
+        <activity
+            android:name=".TransientLoadActivity"
+            android:exported="false"
+            android:theme="@style/Theme.KetchIntegrationTests" />
     </application>
 
 </manifest> 

--- a/integration-tests/src/main/java/com/ketch/android/integration/tests/TransientLoadActivity.kt
+++ b/integration-tests/src/main/java/com/ketch/android/integration/tests/TransientLoadActivity.kt
@@ -1,0 +1,22 @@
+package com.ketch.android.integration.tests
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * Calls load() and finishes immediately, before the boot completes, to reproduce a
+ * transient Activity's destroy silently killing an in-flight load() started elsewhere.
+ */
+class TransientLoadActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val app = application as IntegrationTestApp
+        app.ketch.load()
+
+        startActivity(Intent(this, SecondActivity::class.java))
+        finish()
+    }
+}

--- a/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
+++ b/ketchsdk/src/main/java/com/ketch/android/Ketch.kt
@@ -95,6 +95,10 @@ class Ketch private constructor(
     // Reference to the active webView to prevent multiple webView instances existence
     private var activeWebView: KetchWebView? = null
 
+    // The Activity whose context built activeWebView, if any. Used by onHostDestroyed
+    // to avoid tearing down a WebView owned by an Activity other than the one being destroyed.
+    private var activeWebViewHost: WeakReference<FragmentActivity>? = null
+
     // Cache key for the config/presentation inputs baked into the boot HTML (excludes show type/tabs)
     private var loadedSignature: String? = null
 
@@ -725,8 +729,6 @@ class Ketch private constructor(
     private fun resolveFragmentManager(): FragmentManager? =
         resolveHost()?.supportFragmentManager ?: seedFragmentManager?.get()
 
-    private fun resolveWebViewContext(): Context = resolveHost() ?: context
-
     private fun reportNoHostError() {
         isShowingExperience = false
         Log.e(TAG, "No active Activity to host the Ketch experience")
@@ -796,7 +798,7 @@ class Ketch private constructor(
         if (isChangingConfigurations) {
             if (!isShowingExperience) {
                 synchronized(lock) {
-                    cleanupWebView()
+                    tearDownWebViewIfOwnedBy(destroyedActivity)
                 }
             }
             return
@@ -804,9 +806,7 @@ class Ketch private constructor(
 
         if (!isShowingExperience) {
             synchronized(lock) {
-                if (activeWebView != null) {
-                    cleanupWebView()
-                }
+                tearDownWebViewIfOwnedBy(destroyedActivity)
             }
             return
         }
@@ -816,6 +816,14 @@ class Ketch private constructor(
         synchronized(lock) {
             resetShowingState(HideExperienceStatus.None)
         }
+    }
+
+    // An unrelated Activity's destroy must not kill a WebView tied to a different, still-alive host
+    private fun tearDownWebViewIfOwnedBy(destroyedActivity: Activity) {
+        val host = activeWebViewHost?.get() ?: return
+        if (host !== destroyedActivity) return
+        Log.d(TAG, "onHostDestroyed: tearing down WebView owned by ${host.javaClass.simpleName}")
+        cleanupWebView()
     }
 
     private fun resetShowingState(dismissStatus: HideExperienceStatus) {
@@ -932,6 +940,7 @@ class Ketch private constructor(
     private fun cleanupWebView() {
         activeWebView?.kill()
         activeWebView = null
+        activeWebViewHost = null
         loadedSignature = null
         pendingTrigger = null
     }
@@ -950,7 +959,8 @@ class Ketch private constructor(
             // Use Activity context for WebView so native popups (e.g., <select> dropdowns)
             // can obtain a valid window token. Falls back to applicationContext when no
             // foreground Activity is tracked (callbacks still resolve; display needs a host).
-            val webViewContext = resolveWebViewContext()
+            val webViewHost = resolveHost()
+            val webViewContext = webViewHost ?: context
             val webView = KetchWebView(webViewContext, shouldRetry)
 
             // Enable debug mode
@@ -1072,6 +1082,7 @@ class Ketch private constructor(
                     synchronized(lock) {
                         if (!retainWebView) {
                             activeWebView = null
+                            activeWebViewHost = null
                             loadedSignature = null
                         } else {
                             retainWebViewOnDismiss = true
@@ -1162,6 +1173,7 @@ class Ketch private constructor(
             }
 
             activeWebView = webView
+            activeWebViewHost = webViewHost?.let { WeakReference(it) }
 
             return activeWebView
         }

--- a/sample-app-compose/src/main/AndroidManifest.xml
+++ b/sample-app-compose/src/main/AndroidManifest.xml
@@ -31,6 +31,10 @@
             android:name=".SecondActivity"
             android:exported="false"
             android:theme="@style/Theme.KetchCompose" />
+        <activity
+            android:name=".TransientLoadActivity"
+            android:exported="false"
+            android:theme="@style/Theme.KetchCompose" />
     </application>
 
 </manifest>

--- a/sample-app-compose/src/main/java/com/ketch/android/sample/compose/KetchSampleApp.kt
+++ b/sample-app-compose/src/main/java/com/ketch/android/sample/compose/KetchSampleApp.kt
@@ -62,6 +62,7 @@ fun KetchSampleApp(
     onShowConsent: () -> Unit,
     onShowPreferences: () -> Unit,
     onOpenSecondActivity: () -> Unit,
+    onOpenTransientLoadActivity: () -> Unit,
     onLogSharedPreferences: () -> Unit,
     onTriggerFunction: () -> Unit,
     onGetJurisdiction: () -> Unit,
@@ -152,6 +153,15 @@ fun KetchSampleApp(
                     colors = ButtonDefaults.buttonColors(containerColor = KetchPurple),
                 ) {
                     Text("Open Second Activity", fontSize = 14.sp, fontWeight = FontWeight.Medium)
+                }
+                Spacer(Modifier.height(12.dp))
+                Button(
+                    onClick = onOpenTransientLoadActivity,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(8.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = KetchPurple),
+                ) {
+                    Text("Repro: Transient Activity Load", fontSize = 14.sp, fontWeight = FontWeight.Medium)
                 }
                 Spacer(Modifier.height(24.dp))
                 SectionHeader("Event Log")

--- a/sample-app-compose/src/main/java/com/ketch/android/sample/compose/MainActivity.kt
+++ b/sample-app-compose/src/main/java/com/ketch/android/sample/compose/MainActivity.kt
@@ -56,6 +56,10 @@ class MainActivity : AppCompatActivity() {
                     logEntries.add("Opening SecondActivity")
                     startActivity(Intent(this, SecondActivity::class.java))
                 },
+                onOpenTransientLoadActivity = {
+                    logEntries.add("Opening TransientLoadActivity")
+                    startActivity(Intent(this, TransientLoadActivity::class.java))
+                },
                 onLogSharedPreferences = { logSharedPreferences() },
                 onTriggerFunction = {
                     Log.d(TAG, "trigger('demoFunction') called")

--- a/sample-app-compose/src/main/java/com/ketch/android/sample/compose/TransientLoadActivity.kt
+++ b/sample-app-compose/src/main/java/com/ketch/android/sample/compose/TransientLoadActivity.kt
@@ -1,0 +1,28 @@
+package com.ketch.android.sample.compose
+
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * Calls load() and finishes immediately, before the boot completes, to reproduce a
+ * transient Activity's destroy silently killing an in-flight load() started elsewhere.
+ */
+class TransientLoadActivity : AppCompatActivity() {
+
+    companion object {
+        private const val TAG = "KetchCompose"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val app = application as ComposeSampleApplication
+        Log.d(TAG, "TransientLoadActivity: load() called, finishing immediately")
+        app.ketch.load()
+
+        startActivity(Intent(this, MainActivity::class.java))
+        finish()
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> `Ketch.onHostDestroyed()` tore down the in-flight `activeWebView` boot whenever *any* Activity in the app was destroyed while `!isShowingExperience`, with no check that the destroyed Activity was the one that actually owned the WebView's context. A transient Activity that calls `load()` and finishes quickly (a splash screen, a redirect Activity, or navigating away before boot completes) would silently kill a boot that could belong to a completely different, still-alive Activity — no error, no callback, just a dropped `load()`. This adds `activeWebViewHost`, recorded at WebView-creation time, and scopes teardown to only fire when the destroyed Activity is that recorded owner — mirroring the early-return-when-no-owner behavior the pre-existing `dialogHost` ownership check already uses a few lines above it. Also corrects two integration tests (`KetchSdkIntegrationTest.testConsentBannerUserInteraction`, `ZTriggerFunctionTest.warmWebView_dispatchesTriggerWithoutError`) whose assumptions no longer matched the live `ketch_samples`/`android` deployment plan's actual banner button semantics and `trigger()`'s documented behavior while an experience is showing.

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Reproduced the failure live by adding a `TransientLoadActivity` to `sample-app-compose` that calls `load()` then finishes immediately; logcat showed the boot progress to 80% then `webViewClient coroutines cancelled`, with `onConfigUpdated` never firing, pre-fix. Added `ZTransientActivityLoadSurvivesTest` (integration-tests) reproducing the same mechanism via `ActivityScenario` — fails pre-fix (30s timeout), passes post-fix. Verified the fix wasn't a false positive by stashing just the `Ketch.kt` change and re-running the full 39-test instrumentation suite — identical failure set with/without it, confirming nothing else in the suite depends on the old unconditional-teardown behavior. Full suite (`:integration-tests:connectedDebugAndroidTest`) is 39/39 passing, and `:ketchsdk:testDebugUnitTest` passes.

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A — no tracked issue; found and fixed while investigating a customer-reported early-`load()` failure.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.