### PR TITLE
fix(deps): pin build-tooling deps to advisory-clear versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,32 @@ buildscript {
             'gson'        : '2.13.2',
             'webkit'      : '1.15.0'
     ]
+    // Build-tooling deps pinned to advisory-clear versions (KD-17795). None ship in the AAR.
+    ext.securityPins = [
+            'org.bitbucket.b_c:jose4j:0.9.6',
+            'org.bouncycastle:bcprov-jdk18on:1.84',
+            'org.bouncycastle:bcpkix-jdk18on:1.84',
+            'org.bouncycastle:bcutil-jdk18on:1.84',
+            'org.apache.commons:commons-lang3:3.18.0',
+            'org.apache.httpcomponents:httpclient:4.5.14',
+            'com.fasterxml.jackson.core:jackson-core:2.18.6',
+            'com.fasterxml.jackson.core:jackson-databind:2.18.6',
+            'com.fasterxml.jackson.core:jackson-annotations:2.18.6',
+            'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.18.6',
+            'com.fasterxml.jackson.module:jackson-module-kotlin:2.18.6',
+            'com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.18.6',
+            'io.netty:netty-buffer:4.1.133.Final',
+            'io.netty:netty-codec:4.1.133.Final',
+            'io.netty:netty-codec-http:4.1.133.Final',
+            'io.netty:netty-codec-http2:4.1.133.Final',
+            'io.netty:netty-codec-socks:4.1.133.Final',
+            'io.netty:netty-common:4.1.133.Final',
+            'io.netty:netty-handler:4.1.133.Final',
+            'io.netty:netty-handler-proxy:4.1.133.Final',
+            'io.netty:netty-resolver:4.1.133.Final',
+            'io.netty:netty-transport:4.1.133.Final',
+            'io.netty:netty-transport-native-unix-common:4.1.133.Final'
+    ]
     repositories {
         google()
         mavenCentral()
@@ -33,9 +59,11 @@ buildscript {
         classpath "de.mannodermaus.gradle.plugins:android-junit5:2.0.1"
         classpath "com.github.ben-manes:gradle-versions-plugin:0.52.0"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:14.0.1"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "org.jetbrains.kotlin:compose-compiler-gradle-plugin:${versions.kotlin}"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}"
+    }
+    configurations.classpath {
+        resolutionStrategy { force securityPins }
     }
 }
 
@@ -47,6 +75,12 @@ allprojects {
         maven { url 'https://jitpack.io' }
         maven { url "https://dl.cloudsmith.io/public/indooratlas/mvn-public/maven" }
         maven { url "https://software.mobile.pendo.io/artifactory/android-release" }
+    }
+    configurations.configureEach {
+        // Dokka 1.9.20's worker classpath breaks on Jackson 2.18 (TypeFactory signature change).
+        if (!name.startsWith('dokka')) {
+            resolutionStrategy { force rootProject.ext.securityPins }
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ buildscript {
             'org.bouncycastle:bcutil-jdk18on:1.84',
             'org.apache.commons:commons-lang3:3.18.0',
             'org.apache.httpcomponents:httpclient:4.5.14',
+            // jetifier-processor pulls 2.0.6 (XXE, CVE-2021-33813)
+            'org.jdom:jdom2:2.0.6.1',
+            // already resolves to 3.25.5, but only via highest-wins over a 3.22.3 request
+            'com.google.protobuf:protobuf-java:3.25.5',
             'com.fasterxml.jackson.core:jackson-core:2.18.6',
             'com.fasterxml.jackson.core:jackson-databind:2.18.6',
             'com.fasterxml.jackson.core:jackson-annotations:2.18.6',


### PR DESCRIPTION
## Description of this change

Clears 12 of the 15 [Vulnerabilities 2026](https://ketch-com.atlassian.net/browse/KD-17795) advisories filed against this repo.

None of the flagged packages is declared in any module's `dependencies` block. I resolved the actual graphs (`./gradlew buildEnvironment` and `:ketchsdk:dependencies`) to find where they really come from:

| source | packages |
|---|---|
| Gradle buildscript classpath | jose4j, bcprov/bcpkix/bcutil, jackson-*, commons-lang3, httpclient |
| AGP's `_internal-unified-test-platform-*` configurations | the entire Netty family (via `io.grpc:grpc-netty`) |
| Dokka `dokka*Runtime` / `dokka*Plugin` | jackson-* |

**Critically: `releaseRuntimeClasspath` contains none of them.** The published `ketchsdk` AAR resolves to androidx + gson + kotlin-stdlib only, so none of these advisories has ever been reachable by an SDK consumer. This PR is hygiene on the build toolchain, not a fix to shipped code.

Because nothing declares these packages, there is no version string to edit — `resolutionStrategy.force` is the only lever the repo has. Pins are applied in two places: the `buildscript` classpath, and every project configuration except Dokka's.

### Versions moved

| package | before | after | target | ticket |
|---|---|---|---|---|
| org.bitbucket.b_c:jose4j | 0.9.5 | 0.9.6 | 0.9.6 | KD-17817 |
| org.bouncycastle:bcpkix-jdk18on | 1.79 | 1.84 | 1.84 | KD-17878 |
| org.bouncycastle:bcprov-jdk18on | 1.79 | 1.84 | 1.84 | KD-17882 |
| org.apache.commons:commons-lang3 | 3.16.0 | 3.18.0 | 3.18.0 | KD-17841 |
| org.apache.httpcomponents:httpclient | 4.5.6 / 4.5.14 | 4.5.14 | 4.5.13 | KD-17848 |
| io.netty:netty-codec | 4.1.93 / 4.1.110 | 4.1.133.Final | 4.1.133 | KD-17883 |
| io.netty:netty-codec-http | 4.1.93 / 4.1.110 | 4.1.133.Final | 4.1.125–4.1.133 | KD-17825, KD-17843, KD-17885, KD-17937 |
| io.netty:netty-codec-http2 | 4.1.93 / 4.1.110 | 4.1.133.Final | 4.1.132–4.1.133 | KD-17826, KD-17884 |

The whole Netty family is pinned to one version, not just the three flagged artifacts — Netty requires aligned module versions, and mixing 4.1.93 with 4.1.133 would be a runtime hazard in UTP.

`bcutil-jdk18on` is pinned alongside bcprov/bcpkix for the same alignment reason, though no advisory names it.

### Deliberately not covered

**Jackson (KD-17836)** is only partly cleared. It moves to 2.18.6 on the buildscript classpath and in AGP's configurations, but Dokka's worker configurations stay on 2.12.7. Dokka 1.9.20 binds to Jackson 2.12's `TypeFactory(LRUMap)` constructor and dies at `:ketchsdk:dokkaHtmlPartial` with `'void com.fasterxml.jackson.databind.type.TypeFactory.<init>(...)'` when forced onto 2.18. Clearing it needs a Dokka 2.x upgrade, which is a real migration — `dokkaHtmlMultiModule` no longer exists, the output path changes (so `packageDoc` moves with it), and Dokka 2 registers its own `clean` task that collides with the one in this file. That belongs in its own PR, not bundled into a dependency pin.

**Logback (KD-17859, KD-17936)** is not fixed because `ch.qos.logback` does not appear anywhere in this project's resolved graphs — not in any module configuration, not on the buildscript classpath. Those two tickets appear to be scanner artifacts and should be dismissed rather than fixed here.

I also dropped a duplicate `kotlin-gradle-plugin` classpath line that was declared twice in the same `dependencies` block.

## Why is this change being made?

- [x] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

Local, JDK 17.0.20 + Android SDK platform 36 / build-tools 36, Gradle 9.3.1 wrapper:

- `./gradlew clean assembleRelease test` — **passes**, produces `ketchsdk/build/outputs/aar/ketchsdk-release.aar`
- `./gradlew dokkaHtmlMultiModule` — **passes** (this is what forced the Dokka carve-out; it fails without it)
- `./gradlew :integration-tests:assembleDebugAndroidTest` — **passes**, so the instrumented-test compile path survives the Netty pin
- `./gradlew ktlintCheck` — **passes**

To verify the pins took effect:
```
./gradlew buildEnvironment | grep -E 'jose4j|bouncycastle|netty|commons-lang3|httpclient'
./gradlew :ketchsdk:dependencies | grep -E 'netty|jackson'
```
Every flagged coordinate shows `-> <pinned version>`.

To confirm nothing reached the shipped artifact:
```
./gradlew :ketchsdk:dependencies --configuration releaseRuntimeClasspath
```
No Netty, Jackson, Bouncy Castle, jose4j, commons-lang3 or httpclient appears.

`connectedAndroidTest` has now been run on an emulator (AVD `ketch_test_36`, `system-images;android-36;google_apis;arm64-v8a`, headless). The UTP Netty pin holds at runtime, not just at compile time.

- this branch: 12 tests, 10 pass, 2 fail
- `main` (89a7cfe), same emulator: 12 tests, 10 pass, **the same 2 fail**

```
KetchSdkIntegrationTest > testConsentBannerUserInteraction
  java.lang.AssertionError: Purpose 'analytics_900' should be false after opt out
KetchSdkIntegrationTest > testShowConsentDisplaysDialog
  java.lang.AssertionError: WebView validation should have been received
```

Both failures pre-date this PR. They exercise the live consent WebView and network path, so they look environment or org-config dependent rather than build-tooling related, and are out of scope here.

No tests were added: this changes no source, and the repo has no test suite covering build configuration.

## Related issues

KD-17817, KD-17825, KD-17826, KD-17841, KD-17843, KD-17848, KD-17878, KD-17882, KD-17883, KD-17884, KD-17885, KD-17937 (fixed)
KD-17836 (partial), KD-17859, KD-17936 (not reproducible in this repo)

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Gradle resolution-only hygiene with an explicit Dokka carve-out; no application source or shipped SDK dependency graph changes.
> 
> **Overview**
> Addresses **KD-17795** by forcing transitive **build-only** dependencies (jose4j, Bouncy Castle, Commons Lang3, HttpClient, Jackson, full Netty stack) to patched versions via a shared `ext.securityPins` list. Pins apply on the **buildscript classpath** and on **all project configurations except Dokka’s**, so Dokka 1.9.20 can keep Jackson 2.12 and `dokkaHtmlPartial` still works.
> 
> Also removes a **duplicate** `kotlin-gradle-plugin` classpath entry. **No SDK/AAR runtime dependencies change**—these libraries were never on `releaseRuntimeClasspath`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 520d9d8a8a40aaebd83de5e178292148ccff3de1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
