### PR TITLE
test(android): add general LeakCanary leak detection to integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,8 @@ buildscript {
             'gson'        : '2.13.2',
             'okhttp'      : '4.12.0',
             'coroutines'  : '1.10.2',
-            'webkit'      : '1.15.0'
+            'webkit'      : '1.15.0',
+            'leakcanary'  : '2.14'
     ]
     repositories {
         google()

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -71,4 +71,9 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.7.0'
     androidTestImplementation 'androidx.test:rules:1.7.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
+
+    // Memory-leak detection: watches destroyed Activities/Fragments in the app-under-test
+    // process and lets instrumented tests assert nothing is retained after teardown.
+    debugImplementation "com.squareup.leakcanary:leakcanary-android:${versions.leakcanary}"
+    androidTestImplementation "com.squareup.leakcanary:leakcanary-android-instrumentation:${versions.leakcanary}"
 } 

--- a/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/LeakCheckedInstrumentedTest.kt
+++ b/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/LeakCheckedInstrumentedTest.kt
@@ -1,0 +1,31 @@
+package com.ketch.android.integration.tests
+
+import leakcanary.AppWatcher
+import leakcanary.DetectLeaksAfterTestSuccess
+import org.junit.Rule
+
+/**
+ * Base for instrumented tests that should be checked for Activity/Fragment/View leaks.
+ * On test success (after @After has run), LeakCanary dumps the heap and fails the test if any
+ * watched object (a destroyed Activity/Fragment, or one registered via [watchExpectedGone]) is
+ * still retained. Subclasses keep their own @Before/@After; this only adds the leak-check rule.
+ *
+ * Opt a single test method out with @leakcanary.SkipLeakDetection("reason") when retention is
+ * deliberate for that test.
+ */
+abstract class LeakCheckedInstrumentedTest {
+
+    @get:Rule
+    val detectLeaksRule = DetectLeaksAfterTestSuccess()
+
+    /**
+     * Registers [instance] to be asserted weakly-reachable, in addition to the auto-watched
+     * Activities/Fragments. Useful for asserting a specific retained object (e.g. the SDK's
+     * internal WebView) is released, independent of which Activity happens to own it.
+     */
+    protected fun watchExpectedGone(instance: Any?, reason: String) {
+        if (instance != null) {
+            AppWatcher.objectWatcher.expectWeaklyReachable(instance, reason)
+        }
+    }
+}

--- a/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/ZAutoDismissOnNavigationTest.kt
+++ b/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/ZAutoDismissOnNavigationTest.kt
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicReference
  * leaves the SDK able to show experiences from the new Activity.
  */
 @RunWith(AndroidJUnit4::class)
-class ZAutoDismissOnNavigationTest {
+class ZAutoDismissOnNavigationTest : LeakCheckedInstrumentedTest() {
 
     private lateinit var app: IntegrationTestApp
     private lateinit var mainScenario: ActivityScenario<MainActivity>

--- a/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/ZBenignLifecycleNoDismissTest.kt
+++ b/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/ZBenignLifecycleNoDismissTest.kt
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit
  * an active experience or kill the WebView.
  */
 @RunWith(AndroidJUnit4::class)
-class ZBenignLifecycleNoDismissTest {
+class ZBenignLifecycleNoDismissTest : LeakCheckedInstrumentedTest() {
 
     private lateinit var app: IntegrationTestApp
     private lateinit var mainScenario: ActivityScenario<MainActivity>

--- a/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/ZCrossActivityShowTest.kt
+++ b/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/ZCrossActivityShowTest.kt
@@ -23,7 +23,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
-class ZCrossActivityShowTest {
+class ZCrossActivityShowTest : LeakCheckedInstrumentedTest() {
 
     private lateinit var app: IntegrationTestApp
     private lateinit var mainScenario: ActivityScenario<MainActivity>

--- a/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/ZTransientActivityLoadSurvivesTest.kt
+++ b/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/ZTransientActivityLoadSurvivesTest.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit
  * Verifies the boot survives the transient Activity's destroy instead of being killed.
  */
 @RunWith(AndroidJUnit4::class)
-class ZTransientActivityLoadSurvivesTest {
+class ZTransientActivityLoadSurvivesTest : LeakCheckedInstrumentedTest() {
 
     private lateinit var app: IntegrationTestApp
     private lateinit var mainScenario: ActivityScenario<MainActivity>

--- a/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/ZWebViewLeakOnStopTest.kt
+++ b/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/ZWebViewLeakOnStopTest.kt
@@ -11,6 +11,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.ketch.android.data.HideExperienceStatus
 import com.ketch.android.data.WillShowExperienceType
+import leakcanary.LeakAssertions
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -28,7 +29,7 @@ import java.util.concurrent.TimeUnit
  * Android does not guarantee. Runs after core suite (Z prefix).
  */
 @RunWith(AndroidJUnit4::class)
-class ZWebViewLeakOnStopTest {
+class ZWebViewLeakOnStopTest : LeakCheckedInstrumentedTest() {
 
     private lateinit var app: IntegrationTestApp
     private lateinit var scenario: ActivityScenario<MainActivity>
@@ -125,5 +126,13 @@ class ZWebViewLeakOnStopTest {
         )
         assertFalse("WebView should be released", app.hasActiveWebView())
         assertNull("Loaded signature should be cleared", app.getLoadedSignature())
+
+        // Heap-verify the WebView is actually collectible now. Deliberately does not capture the
+        // WebView instance in a local: a named local stays live on this method's stack for the
+        // rest of the call, which would itself be a GC root and mask a real release with a false
+        // "still reachable" positive. LeakCanary's automatic FragmentWatcher (KetchDialogFragment
+        // owns the WebView as a child view) already watches this instance with no test code
+        // needed; this assertion just forces the heap dump/analysis at this exact checkpoint.
+        LeakAssertions.assertNoLeaks()
     }
 }

--- a/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/ZWebViewRetentionTest.kt
+++ b/integration-tests/src/androidTest/java/com/ketch/android/integration/tests/ZWebViewRetentionTest.kt
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicReference
  * cache invalidation, and teardown paths. Runs after core suite (Z prefix).
  */
 @RunWith(AndroidJUnit4::class)
-class ZWebViewRetentionTest {
+class ZWebViewRetentionTest : LeakCheckedInstrumentedTest() {
 
     private lateinit var app: IntegrationTestApp
     private lateinit var scenario: ActivityScenario<MainActivity>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> Adds LeakCanary instrumentation support to :integration-tests so the whole class of Activity/Fragment/WebView retention leaks is caught automatically, rather than relying only on hand-written per-scenario regression tests (the recent retained-WebView leak fixed in a47d4c6 / 48815f0 already had one such test, ZWebViewLeakOnStopTest).

- leakcanary-android (debug watchers) + leakcanary-android-instrumentation wired into integration-tests/build.gradle.
- New LeakCheckedInstrumentedTest base class contributing a DetectLeaksAfterTestSuccess rule; adopted by the six lifecycle test classes (ZWebViewLeakOnStopTest, ZWebViewRetentionTest, ZCrossActivityShowTest, ZAutoDismissOnNavigationTest, ZBenignLifecycleNoDismissTest, ZTransientActivityLoadSurvivesTest).
- ZWebViewLeakOnStopTest additionally asserts no leaks at the exact point the retained WebView should already be released.

## Why is this change being made?

- [x] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified end-to-end on an emulator: full suite passes clean, and a negative control (temporarily reverting the 48815f0 fix) makes the test fail as expected.

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Gradle and instrumentation changes; no production SDK or runtime behavior is modified.
> 
> **Overview**
> Adds **LeakCanary** to the `:integration-tests` module so instrumented lifecycle tests fail automatically when destroyed Activities, Fragments, or related views stay retained after a passing test.
> 
> Gradle picks up `leakcanary` **2.14** (`leakcanary-android` on debug, `leakcanary-android-instrumentation` for androidTest). A new **`LeakCheckedInstrumentedTest`** base contributes `DetectLeaksAfterTestSuccess` (post-`@After` heap check) and optional **`watchExpectedGone`** for extra weak-reachability assertions.
> 
> Six **`Z*`** lifecycle suites now extend that base. **`ZWebViewLeakOnStopTest`** still uses SDK-level release checks and additionally calls **`LeakAssertions.assertNoLeaks()`** right after navigation, to heap-verify the retained WebView is collectible without holding a local reference that would skew the analysis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59379ef6310a4c79cea5c5a0928c5c62efe5ff4f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->